### PR TITLE
feat: make quipucordsctl localizable (l10n/i18n/gettext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SOURCE_CODE_DIR=quipucordsctl
 LOCALES_DIR="${SOURCE_CODE_DIR}"/locale
 
 # export strings to template
-uv run pybabel extract -o "${LOCALES_DIR}"/"${DOMAIN}".pot "${SOURCE_CODE_DIR}"
+uv run bin/translations.py
 
 # create each language-specific po file (first time only)
 # replace "XX" with desired ISO 639-1 (two-letter) language code (e.g. "es")

--- a/README.md
+++ b/README.md
@@ -15,25 +15,14 @@ uv run pytest
 ## l10n/i18n
 
 ```sh
-DOMAIN=messages
-SOURCE_CODE_DIR=quipucordsctl
-LOCALES_DIR="${SOURCE_CODE_DIR}"/locale
-
 # export strings to template
-uv run bin/translations.py
-
-# create each language-specific po file (first time only)
-# replace "XX" with desired ISO 639-1 (two-letter) language code (e.g. "es")
-# https://www.gnu.org/software/gettext/manual/html_node/Usual-Language-Codes.html
-# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
-uv run pybabel init -i "${LOCALES_DIR}"/"${DOMAIN}".pot -d "${LOCALES_DIR}" -D "${DOMAIN}" -l XX
+uv run bin/translations.py extract
 
 # update each language-specific po file
-# replace "XX" with desired ISO 639-1 (two-letter) language code (e.g. "es")
-uv run pybabel update -i "${LOCALES_DIR}"/"${DOMAIN}".pot -d "${LOCALES_DIR}" -D "${DOMAIN}" -l XX
+uv run bin/translations.py update
 
 # compile binary mo file(s) after filling out all po file(s)
-uv run pybabel compile -d "${LOCALES_DIR}" -D "${DOMAIN}"
+uv run bin/translations.py compile
 ```
 
 ## running

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # quipucordsctl
 
+## setup
+
 ```sh
 git clone git@github.com:quipucords/quipucordsctl.git quipucordsctl
 cd quipucordsctl
@@ -8,6 +10,37 @@ uv sync
 uv run ruff check
 uv run ruff format --check
 uv run pytest
+```
 
-uv run python -m quipucordsctl
+## l10n/i18n
+
+```sh
+DOMAIN=messages
+SOURCE_CODE_DIR=quipucordsctl
+LOCALES_DIR="${SOURCE_CODE_DIR}"/locale
+
+# export strings to template
+uv run pybabel extract -o "${LOCALES_DIR}"/"${DOMAIN}".pot "${SOURCE_CODE_DIR}"
+
+# create each language-specific po file (first time only)
+# replace "XX" with desired ISO 639-1 (two-letter) language code (e.g. "es")
+# https://www.gnu.org/software/gettext/manual/html_node/Usual-Language-Codes.html
+# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+uv run pybabel init -i "${LOCALES_DIR}"/"${DOMAIN}".pot -d "${LOCALES_DIR}" -D "${DOMAIN}" -l XX
+
+# update each language-specific po file
+# replace "XX" with desired ISO 639-1 (two-letter) language code (e.g. "es")
+uv run pybabel update -i "${LOCALES_DIR}"/"${DOMAIN}".pot -d "${LOCALES_DIR}" -D "${DOMAIN}" -l XX
+
+# compile binary mo file(s) after filling out all po file(s)
+uv run pybabel compile -d "${LOCALES_DIR}" -D "${DOMAIN}"
+```
+
+## running
+
+```sh
+uv run python -m quipucordsctl --help
+
+# override the locale using LC_MESSAGES, LC_ALL, LANGUAGE, or LANG 
+LANG=pt uv run python -m quipucordsctl --help
 ```

--- a/bin/translations.py
+++ b/bin/translations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Extract translations for gettext to cover code *and* specific stdlib modules.
+
+Simply invoking pybabel, xgettext, and similar tools on this project does not
+automatically extract any strings gettext-wrapped inside Python's standard library
+that we might expose to the end user (e.g. argparse). This script attempts to find
+specific Python stdlib source files and include their strings with this project's
+strings when exporting the messages.pot file.
+"""
+
+import pathlib
+import subprocess
+import sys
+import sysconfig
+
+
+def get_code_paths(source_code_dir: pathlib.Path, *stdlib_file_names: str) -> list:
+    """Get a list of paths that contain gettext-wrapped strings to localize."""
+    code_paths = [source_code_dir]
+    stdlib_path = pathlib.Path(sysconfig.get_paths()["stdlib"])
+    for stdlib_file_name in stdlib_file_names:
+        stdlib_file_path = stdlib_path / stdlib_file_name
+        if stdlib_file_path.exists():
+            code_paths.append(stdlib_file_path)
+    return code_paths
+
+
+pybabel_path = pathlib.Path(sys.prefix) / "bin" / "pybabel"
+source_code_dir = pathlib.Path(__file__).parent.parent / "quipucordsctl"
+locales_dir = source_code_dir / "locale"
+paths: list[str] = get_code_paths(source_code_dir, "argparse.py")
+subprocess.run(  # noqa: S603
+    [
+        pybabel_path,
+        "extract",
+        "-o",
+        str(locales_dir / "messages.pot"),
+        *(str(path) for path in paths),
+    ],
+    check=False,
+)

--- a/bin/translations.py
+++ b/bin/translations.py
@@ -1,42 +1,125 @@
 #!/usr/bin/env python3
 """
-Extract translations for gettext to cover code *and* specific stdlib modules.
+Process translations for gettext strings in our code *and* specific stdlib modules.
 
 Simply invoking pybabel, xgettext, and similar tools on this project does not
 automatically extract any strings gettext-wrapped inside Python's standard library
 that we might expose to the end user (e.g. argparse). This script attempts to find
 specific Python stdlib source files and include their strings with this project's
 strings when exporting the messages.pot file.
+
+LOCALES should include a list of two-letter language codes (e.g. "pt")
+that we intend to localize/translate. See here for lists of valid codes:
+https://www.gnu.org/software/gettext/manual/html_node/Usual-Language-Codes.html
+https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 """
 
+import argparse
 import pathlib
 import subprocess
 import sys
 import sysconfig
 
+DOMAIN = "messages"
+PYBABEL_BIN = pathlib.Path(sys.prefix) / "bin" / "pybabel"
+SOURCE_CODE_DIR = pathlib.Path(__file__).parent.parent / "quipucordsctl"
+LOCALES_DIR = SOURCE_CODE_DIR / "locale"
+PYTHON_STDLIB_FILES = ["argparse.py"]
+LOCALES = []
 
-def get_code_paths(source_code_dir: pathlib.Path, *stdlib_file_names: str) -> list:
+
+def get_code_paths() -> list:
     """Get a list of paths that contain gettext-wrapped strings to localize."""
-    code_paths = [source_code_dir]
+    code_paths = [SOURCE_CODE_DIR]
     stdlib_path = pathlib.Path(sysconfig.get_paths()["stdlib"])
-    for stdlib_file_name in stdlib_file_names:
+    for stdlib_file_name in PYTHON_STDLIB_FILES:
         stdlib_file_path = stdlib_path / stdlib_file_name
         if stdlib_file_path.exists():
             code_paths.append(stdlib_file_path)
     return code_paths
 
 
-pybabel_path = pathlib.Path(sys.prefix) / "bin" / "pybabel"
-source_code_dir = pathlib.Path(__file__).parent.parent / "quipucordsctl"
-locales_dir = source_code_dir / "locale"
-paths: list[str] = get_code_paths(source_code_dir, "argparse.py")
-subprocess.run(  # noqa: S603
-    [
-        pybabel_path,
-        "extract",
-        "-o",
-        str(locales_dir / "messages.pot"),
-        *(str(path) for path in paths),
-    ],
-    check=False,
-)
+def translations_extract():
+    """Extract gettext-wrapped strings to messages.pot template file."""
+    paths: list[str] = get_code_paths()
+    try:
+        subprocess.check_call(  # noqa: S603
+            [
+                PYBABEL_BIN,
+                "extract",
+                "-o",
+                str(LOCALES_DIR / f"{DOMAIN}.pot"),
+                *(str(path) for path in paths),
+            ],
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error invoking pybabel extract: {e}")
+        sys.exit(1)
+
+
+def translations_update():
+    """Update locale-specific .po files from the .pot template file."""
+    for locale in LOCALES:
+        locale_path = LOCALES_DIR / locale / "LC_MESSAGES" / f"{DOMAIN}.po"
+        subcommand = "update" if locale_path.exists() else "init"
+        try:
+            subprocess.check_call(  # noqa: S603
+                [
+                    PYBABEL_BIN,
+                    subcommand,
+                    "-i",
+                    str(LOCALES_DIR / f"{DOMAIN}.pot"),
+                    "-d",
+                    str(LOCALES_DIR),
+                    "-D",
+                    DOMAIN,
+                    "-l",
+                    locale,
+                ],
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Error invoking pybabel {subcommand} for locale {locale}: {e}")
+            sys.exit(1)
+
+
+def translations_compile():
+    """Compile locale-specific .mo files from the .po files."""
+    try:
+        subprocess.check_call(  # noqa: S603
+            [
+                PYBABEL_BIN,
+                "compile",
+                "-d",
+                str(LOCALES_DIR),
+                "-D",
+                DOMAIN,
+            ],
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error invoking pybabel compile: {e}")
+        sys.exit(1)
+
+
+def main():
+    """Parse CLI args to invoke requested command."""
+    parser = argparse.ArgumentParser(
+        description="Translation management script using pybabel."
+    )
+    subparsers = parser.add_subparsers(
+        dest="command", required=True, help="Available commands"
+    )
+    subparsers.add_parser("extract", help="Extract strings to .pot file")
+    subparsers.add_parser("update", help="Update translation .po files")
+    subparsers.add_parser("compile", help="Compile binary .mo files")
+    args = parser.parse_args()
+
+    if args.command == "extract":
+        translations_extract()
+    elif args.command == "update":
+        translations_update()
+    elif args.command == "compile":
+        translations_compile()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = []
 
 [dependency-groups]
 dev = [
+    "babel>=2.17.0",
     "coverage>=7.9.2",
     "faker>=37.4.0",
     "pytest>=8.4.1",

--- a/quipucordsctl/__main__.py
+++ b/quipucordsctl/__main__.py
@@ -1,6 +1,18 @@
 """Package command-line entrypoint."""
 
+import gettext
+import pathlib
+
+
+def set_up_gettext():
+    """Set up gettext for string localization."""
+    locale_dir = pathlib.Path(__file__).parent / "locale"
+    gettext.bindtextdomain("messages", str(locale_dir))
+
+
 if __name__ == "__main__":
+    set_up_gettext()
+
     from .main import main
 
     main()

--- a/quipucordsctl/commands/install.py
+++ b/quipucordsctl/commands/install.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def get_help() -> str:
     """Get the help/docstring for this command."""
     return _("Install the %(server_software_name)s server.") % {
-        "server_software_name": settings.SERVER_SOFTWARE
+        "server_software_name": settings.SERVER_SOFTWARE_NAME
     }
 
 

--- a/quipucordsctl/commands/reset_django_secret.py
+++ b/quipucordsctl/commands/reset_django_secret.py
@@ -2,9 +2,15 @@
 
 import argparse
 import logging
+from gettext import gettext as _
 
 logger = logging.getLogger(__name__)
 NOT_A_COMMAND = True  # Until we complete the implementation.
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Reset the server's internal secret encryption key.")
 
 
 def django_secret_is_set() -> bool:
@@ -15,7 +21,9 @@ def django_secret_is_set() -> bool:
 
 def run(args: argparse.Namespace) -> None:
     """Reset the server password."""
-    logger.warning("%s is not yet implemented.", __name__)
+    logger.warning(
+        _("%(command_name)s is not yet implemented."), {"command_name": __name__}
+    )
     # TODO Implement this.
     # TODO Should this also conditionally restart the server?
     # Old bash installer did the following:

--- a/quipucordsctl/commands/reset_server_password.py
+++ b/quipucordsctl/commands/reset_server_password.py
@@ -1,10 +1,16 @@
-"""Reset the admin password."""
+"""Reset the server's login password."""
 
 import argparse
 import logging
+from gettext import gettext as _
 
 logger = logging.getLogger(__name__)
 NOT_A_COMMAND = True  # Until we complete the implementation.
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Reset the server's login password.")
 
 
 def server_password_is_set() -> bool:
@@ -15,7 +21,9 @@ def server_password_is_set() -> bool:
 
 def run(args: argparse.Namespace) -> None:
     """Reset the server password."""
-    logger.warning("%s is not yet implemented.", __name__)
+    logger.warning(
+        _("%(command_name)s is not yet implemented."), {"command_name": __name__}
+    )
     # TODO implement this.
     # TODO Should this also conditionally restart the server?
     # Old bash installer did the following:

--- a/quipucordsctl/commands/uninstall.py
+++ b/quipucordsctl/commands/uninstall.py
@@ -9,11 +9,13 @@ from .. import settings
 logger = logging.getLogger(__name__)
 NOT_A_COMMAND = True  # Until we complete the implementation.
 
+
 def get_help() -> str:
     """Get the help/docstring for this command."""
     return _("Uninstall the %(server_software_name)s server.") % {
-        "server_software_name": settings.SERVER_SOFTWARE
+        "server_software_name": settings.SERVER_SOFTWARE_NAME
     }
+
 
 def run(args: argparse.Namespace) -> None:
     """Uninstall the server."""

--- a/quipucordsctl/commands/uninstall.py
+++ b/quipucordsctl/commands/uninstall.py
@@ -2,16 +2,20 @@
 
 import argparse
 import logging
+from gettext import gettext as _
 
 from .. import settings
-
-__doc__ = f"Uninstall the {settings.SERVER_SOFTWARE_NAME} server."
 
 logger = logging.getLogger(__name__)
 NOT_A_COMMAND = True  # Until we complete the implementation.
 
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Uninstall the %(server_software_name)s server.") % {
+        "server_software_name": settings.SERVER_SOFTWARE
+    }
 
 def run(args: argparse.Namespace) -> None:
     """Uninstall the server."""
-    logger.warning("%s is not yet implemented.", __name__)
+    logger.warning(_("%(command)s is not yet implemented."), {"command": __name__})
     # TODO Implement this.

--- a/quipucordsctl/main.py
+++ b/quipucordsctl/main.py
@@ -4,6 +4,7 @@ import argparse
 import importlib
 import logging
 import pkgutil
+from gettext import gettext as _
 from types import ModuleType
 
 from . import settings
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 def load_commands() -> dict[str, ModuleType]:
     """Dynamically load command modules."""
     commands = {}
-    for _, module_name, _ in pkgutil.iter_modules([settings.COMMANDS_PACKAGE_PATH]):
+    for __, module_name, __ in pkgutil.iter_modules([settings.COMMANDS_PACKAGE_PATH]):
         module = importlib.import_module(f"quipucordsctl.commands.{module_name}")
         if not getattr(module, "NOT_A_COMMAND", False):
             commands[module_name] = module
@@ -30,7 +31,7 @@ def create_parser(commands: dict[str, ModuleType]) -> argparse.ArgumentParser:
         action="count",
         dest="verbosity",
         default=0,
-        help="Increase verbose output",
+        help=_("Increase verbose output"),
     )
     parser.add_argument(
         "-q",
@@ -38,21 +39,21 @@ def create_parser(commands: dict[str, ModuleType]) -> argparse.ArgumentParser:
         action="store_true",
         dest="quiet",
         default=0,
-        help="Quiet output (overrides `-v`/`--verbose`)",
+        help=_("Quiet output (overrides `-v`/`--verbose`)"),
     )
 
     parser.add_argument(
         "-c",
         "--override-conf-dir",
         dest="override_conf_dir",
-        help="Override configuration directory",
+        help=_("Override configuration directory"),
         # TODO specify a type that enforces a valid directory path.
     )
 
     subparsers = parser.add_subparsers(dest="command")
     for command_name, command_module in commands.items():
         command_parser = subparsers.add_parser(
-            command_name, help=command_module.__doc__
+            command_name, help=command_module.get_help()
         )
         if hasattr(command_module, "setup_parser"):
             command_module.setup_parser(command_parser)

--- a/quipucordsctl/settings.py
+++ b/quipucordsctl/settings.py
@@ -3,17 +3,17 @@
 import logging
 import pathlib
 
-PROGRAM_NAME = "quipucordsctl"
-SERVER_SOFTWARE = "quipucords"
-SERVER_SOFTWARE_NAME = "Quipucords"
+PROGRAM_NAME = "quipucordsctl"  # this program's executable command
+SERVER_SOFTWARE_PACKAGE = "quipucords"  # used for constructing server's file paths
+SERVER_SOFTWARE_NAME = "Quipucords"  # server's user-facing "product" name
 
 COMMANDS_PACKAGE_PATH = str(pathlib.Path(__file__).parent.resolve() / "commands")
 
 DEFAULT_LOG_LEVEL = logging.WARNING
 
 _home = pathlib.Path.home()
-SERVER_ENV_DIR = _home / f".config/{SERVER_SOFTWARE}/env"
-SERVER_DATA_DIR = _home / f".local/share/{SERVER_SOFTWARE}"
+SERVER_ENV_DIR = _home / f".config/{SERVER_SOFTWARE_PACKAGE}/env"
+SERVER_DATA_DIR = _home / f".local/share/{SERVER_SOFTWARE_PACKAGE}"
 SYSTEMD_UNITS_DIR = _home / ".config/containers/systemd"
 
 # TODO maybe use pkg_resources.resource_filename when packaging

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 2
 requires-python = ">=3.12, <3.14"
 
 [[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +147,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "babel" },
     { name = "coverage" },
     { name = "faker" },
     { name = "pytest" },
@@ -149,6 +159,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "babel", specifier = ">=2.17.0" },
     { name = "coverage", specifier = ">=7.9.2" },
     { name = "faker", specifier = ">=37.4.0" },
     { name = "pytest", specifier = ">=8.4.1" },


### PR DESCRIPTION
This PR adds a script `bin/translations.py` that updates required files to support gettext localization.

As described simply in the README:

```sh
# export strings to template
uv run bin/translations.py extract

# update each language-specific po file
uv run bin/translations.py update

# compile binary mo file(s) after filling out all po file(s)
uv run bin/translations.py compile
```

We currently support no locales besides default English. So, the "update" and "compile" commands are basically no-ops. However, adding this script prepares us for the expected eventuality of localizing this project to multiple locales/languages.

Demo with a _temporary_ LLM-translated locale that _is not_ committed with this PR's branch:
[![asciicast](https://asciinema.org/a/729289.svg)](https://asciinema.org/a/729289)

## Summary by Sourcery

Prepare quipucordsctl for gettext-based localization by introducing a translation management script, integrating gettext wrappers throughout the CLI commands and entrypoint, updating project dependencies, and documenting the localization workflow.

New Features:
- Add bin/translations.py script with extract, update, and compile commands for managing PO and MO files

Enhancements:
- Wrap user-facing strings and command help text with gettext for localization
- Set up gettext binding in the main entrypoint and add get_help functions in command modules

Build:
- Add Babel as a development dependency in pyproject.toml

Documentation:
- Document the l10n/i18n workflow in README with instructions for extracting, updating, and compiling translations