### PR TITLE
feat: add reset_database_password, reset_redis_password, and install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,22 @@ uv run bin/translations.py update
 uv run bin/translations.py compile
 ```
 
-## running
+## running directly from source
 
 ```sh
 uv run python -m quipucordsctl --help
 
 # override the locale using LC_MESSAGES, LC_ALL, LANGUAGE, or LANG 
 LANG=pt uv run python -m quipucordsctl --help
+```
+
+## running installed from source
+
+```sh
+uv tool uninstall quipucordsctl
+uv tool install --no-cache --from . quipucordsctl
+
+quipucordsctl --help
+
+LANG=pt quipucordsctl --help
 ```

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ uv run bin/translations.py compile
 
 ```sh
 uv run python -m quipucordsctl --help
-
-# override the locale using LC_MESSAGES, LC_ALL, LANGUAGE, or LANG 
-LANG=pt uv run python -m quipucordsctl --help
 ```
 
 ## running installed from source
@@ -77,6 +74,16 @@ uv tool uninstall quipucordsctl
 uv tool install --no-cache --from . quipucordsctl
 
 quipucordsctl --help
+```
 
+## running with custom locale
+
+You can override the locale using `LC_MESSAGES`, `LC_ALL`, `LANGUAGE`, or `LANG`.
+
+```sh
+# when running directly from source
+LANG=pt uv run python -m quipucordsctl --help
+
+# when running installed
 LANG=pt quipucordsctl --help
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,6 @@ lint.ignore = [
     "D203",
     "D403",
 ]
-extend-exclude = [
-    # SystemdUnitParser is vendored. Ignore formatting and errors for now!
-    "src/quipucordsctl/SystemdUnitParser/*"
-]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "D104"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ lint.ignore = [
     "D203",
     "D403",
 ]
+extend-exclude = [
+    # SystemdUnitParser is vendored. Ignore formatting and errors for now!
+    "src/quipucordsctl/SystemdUnitParser/*"
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "D104"]

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -1,8 +1,8 @@
 %global product_name_lower quipucords
 %global product_name_title Quipucords
-%global version_installer 2.1.0
-%global server_image quay.io/quipucords/quipucords:2.1
-%global ui_image quay.io/quipucords/quipucords-ui:2.1
+%global version_installer 2.2.0
+%global server_image quay.io/quipucords/quipucords:2.2
+%global ui_image quay.io/quipucords/quipucords-ui:2.2
 %global templates_dir src/quipucordsctl/templates
 
 ###############################################################

--- a/src/quipucordsctl/cli.py
+++ b/src/quipucordsctl/cli.py
@@ -10,7 +10,7 @@ from types import ModuleType
 
 from podman import errors as podman_errors
 
-from . import settings
+from . import podman_utils, settings
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +109,11 @@ def run():
         except EOFError:  # can occur via control-d input
             print()  # new line for cleaner output before logger
             logger.error(_("Input closed unexpectedly."))
+            sys.exit(1)
+        except podman_utils.PodmanIsNotReadyError as e:
+            # can occur if podman is not available or running
+            print()
+            logger.error(e)
             sys.exit(1)
         except (podman_errors.APIError, podman_errors.PodmanError):
             # can occur if podman is not available or fails unexpectedly

--- a/src/quipucordsctl/cli.py
+++ b/src/quipucordsctl/cli.py
@@ -75,10 +75,16 @@ def configure_logging(verbosity: int = 0, quiet: bool = False) -> int:
         if quiet
         else max(logging.DEBUG, settings.DEFAULT_LOG_LEVEL - (verbosity * 10))
     )
+    log_format = (
+        "%(asctime)s %(levelname)s: %(message)s"
+        if verbosity > 2  # noqa: PLR2004
+        else "%(levelname)s: %(message)s"
+    )
     logging.basicConfig(
-        format="%(levelname)s: %(message)s",
+        format=log_format,
         level=log_level,
         encoding="utf-8",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
     return log_level
 

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -264,6 +264,8 @@ def run(args: argparse.Namespace) -> bool:
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
     podman_utils.ensure_podman_socket()
+    podman_utils.ensure_cgroups_v2()
+
     if not reset_secrets(args):
         return False
 

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -13,6 +13,7 @@ from importlib import resources
 from quipucordsctl import podman_utils, settings, shell_utils
 from quipucordsctl.commands import (
     reset_admin_password,
+    reset_database_password,
     reset_encryption_secret,
     reset_session_secret,
 )
@@ -257,6 +258,12 @@ def run(args: argparse.Namespace) -> bool:
         and not reset_admin_password.run(args)
     ):
         logger.error(_("The install command failed to reset admin password."))
+        return False
+    if (
+        not reset_database_password.database_password_is_set()
+        and not reset_database_password.run(args)
+    ):
+        logger.error(_("The install command failed to reset database password."))
         return False
 
     override_conf_dir_path = None

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -15,6 +15,7 @@ from quipucordsctl.commands import (
     reset_admin_password,
     reset_database_password,
     reset_encryption_secret,
+    reset_redis_password,
     reset_session_secret,
 )
 from quipucordsctl.systemdunitparser import SystemdUnitParser
@@ -236,7 +237,7 @@ def systemctl_reload():
     shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True)
 
 
-def run(args: argparse.Namespace) -> bool:
+def run(args: argparse.Namespace) -> bool:  # noqa: PLR0911
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
     podman_utils.ensure_podman_socket()
@@ -264,6 +265,12 @@ def run(args: argparse.Namespace) -> bool:
         and not reset_database_password.run(args)
     ):
         logger.error(_("The install command failed to reset database password."))
+        return False
+    if (
+        not reset_redis_password.redis_password_is_set()
+        and not reset_redis_password.run(args)
+    ):
+        logger.error(_("The install command failed to reset Redis password."))
         return False
 
     override_conf_dir_path = None

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -238,34 +238,19 @@ def run(args: argparse.Namespace) -> bool:  # noqa: PLR0911
     logger.debug("Starting install command")
     podman_utils.ensure_podman_socket()
 
-    if (
-        not reset_encryption_secret.encryption_secret_is_set()
-        and not reset_encryption_secret.run(args)
-    ):
+    if not reset_encryption_secret.is_set() and not reset_encryption_secret.run(args):
         logger.error(_("The install command failed to reset encryption secret."))
         return False
-    if (
-        not reset_session_secret.session_secret_is_set()
-        and not reset_session_secret.run(args)
-    ):
+    if not reset_session_secret.is_set() and not reset_session_secret.run(args):
         logger.error(_("The install command failed to reset session secret."))
         return False
-    if (
-        not reset_admin_password.admin_password_is_set()
-        and not reset_admin_password.run(args)
-    ):
+    if not reset_admin_password.is_set() and not reset_admin_password.run(args):
         logger.error(_("The install command failed to reset admin password."))
         return False
-    if (
-        not reset_database_password.database_password_is_set()
-        and not reset_database_password.run(args)
-    ):
+    if not reset_database_password.is_set() and not reset_database_password.run(args):
         logger.error(_("The install command failed to reset database password."))
         return False
-    if (
-        not reset_redis_password.redis_password_is_set()
-        and not reset_redis_password.run(args)
-    ):
+    if not reset_redis_password.is_set() and not reset_redis_password.run(args):
         logger.error(_("The install command failed to reset Redis password."))
         return False
 

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -56,10 +56,6 @@ def mkdirs():
             {"dir_path": dir_path},
         )
         dir_path.mkdir(parents=True, exist_ok=True)
-        if not dir_path.is_dir():
-            raise NotADirectoryError(
-                _("%(dir_path)s exists but is not a directory."), {"dir_path": dir_path}
-            )
 
 
 def get_override_conf_path(

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -29,28 +29,18 @@ def get_help() -> str:
 
 def mkdirs():
     """Ensure required data and config directories exist."""
-    for data_dir in DATA_DIRS:
-        dir_path = settings.SERVER_DATA_DIR / data_dir
+    dir_paths = [settings.SERVER_ENV_DIR, settings.SYSTEMD_UNITS_DIR] + [
+        settings.SERVER_DATA_DIR / data_dir for data_dir in DATA_DIRS
+    ]
+    for dir_path in dir_paths:
         logger.debug(
-            _("Ensuring data directory exists: %(dir_path)s"),
+            _("Ensuring directory exists: %(dir_path)s"),
             {"dir_path": dir_path},
         )
         dir_path.mkdir(parents=True, exist_ok=True)
         if not dir_path.is_dir():
             raise NotADirectoryError(
                 _("%(dir_path)s exists but is not a directory."), {"dir_path": dir_path}
-            )
-
-    for config_dir in (settings.SERVER_ENV_DIR, settings.SYSTEMD_UNITS_DIR):
-        logger.debug(
-            _("Ensuring config directory exists: %(config_dir)s"),
-            {"config_dir": config_dir},
-        )
-        config_dir.mkdir(parents=True, exist_ok=True)
-        if not config_dir.is_dir():
-            raise NotADirectoryError(
-                _("%(config_dir)s exists but is not a directory."),
-                {"config_dir": config_dir},
             )
 
 

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -13,7 +13,6 @@ from quipucordsctl.commands import (
     reset_session_secret,
 )
 
-DATA_DIRS = ("data", "db", "log", "sshkeys")
 SYSTEMCTL_USER_RESET_FAILED_CMD = ["systemctl", "--user", "reset-failed"]
 SYSTEMCTL_USER_DAEMON_RELOAD_CMD = ["systemctl", "--user", "daemon-reload"]
 
@@ -29,9 +28,10 @@ def get_help() -> str:
 
 def mkdirs():
     """Ensure required data and config directories exist."""
-    dir_paths = [settings.SERVER_ENV_DIR, settings.SYSTEMD_UNITS_DIR] + [
-        settings.SERVER_DATA_DIR / data_dir for data_dir in DATA_DIRS
-    ]
+    dir_paths = [
+        settings.SERVER_ENV_DIR,
+        settings.SYSTEMD_UNITS_DIR,
+    ] + list(settings.SERVER_DATA_SUBDIRS.values())
     for dir_path in dir_paths:
         logger.debug(
             _("Ensuring directory exists: %(dir_path)s"),

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from gettext import gettext as _
 from importlib import resources
 
-from quipucordsctl import settings, shell_utils
+from quipucordsctl import podman_utils, settings, shell_utils
 from quipucordsctl.commands import (
     reset_admin_password,
     reset_encryption_secret,
@@ -219,13 +219,14 @@ def systemctl_reload():
         _("Reloading systemctl to recognize %(server_software_name)s units"),
         {"server_software_name": settings.SERVER_SOFTWARE_NAME},
     )
-    shell_utils.run_command(SYSTEMCTL_USER_RESET_FAILED_CMD)
-    shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD)
+    shell_utils.run_command(SYSTEMCTL_USER_RESET_FAILED_CMD, quiet=True)
+    shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True)
 
 
 def run(args: argparse.Namespace) -> bool:
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
+    podman_utils.ensure_podman_socket()
 
     if (
         not reset_encryption_secret.encryption_secret_is_set()

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -151,11 +151,15 @@ def write_systemd_unit(
         for section in override_config.sections():
             for option in override_config.options(section):
                 value = override_config.get(section, option)
+                # template_config has a dict-like interface but is not a true dict. You
+                # cannot call get() with defaults to find optional contents. The
+                # following assign to old_value is conceptually like calling
+                # "template_config.get(section, {}).get(option, None)" on true dicts.
                 old_value = (
                     template_config[section][option]
                     if (
-                        section in template_config.sections()
-                        and option in template_config[section]
+                        section in template_config.sections()  # section may not exist
+                        and option in template_config[section]  # option may not exist
                     )
                     else None
                 )

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -58,6 +58,26 @@ def mkdirs():
         dir_path.mkdir(parents=True, exist_ok=True)
 
 
+def reset_secrets(args: argparse.Namespace) -> bool:
+    """Reset various secrets as part of the 'install' process."""
+    if not reset_encryption_secret.is_set() and not reset_encryption_secret.run(args):
+        logger.error(_("The install command failed to reset encryption secret."))
+        return False
+    if not reset_session_secret.is_set() and not reset_session_secret.run(args):
+        logger.error(_("The install command failed to reset session secret."))
+        return False
+    if not reset_admin_password.is_set() and not reset_admin_password.run(args):
+        logger.error(_("The install command failed to reset admin password."))
+        return False
+    if not reset_database_password.is_set() and not reset_database_password.run(args):
+        logger.error(_("The install command failed to reset database password."))
+        return False
+    if not reset_redis_password.is_set() and not reset_redis_password.run(args):
+        logger.error(_("The install command failed to reset Redis password."))
+        return False
+    return True
+
+
 def get_override_conf_path(
     override_conf_dir: pathlib.Path | None, filename: str
 ) -> pathlib.Path | None:
@@ -233,25 +253,11 @@ def systemctl_reload():
     shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True)
 
 
-def run(args: argparse.Namespace) -> bool:  # noqa: PLR0911
+def run(args: argparse.Namespace) -> bool:
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
     podman_utils.ensure_podman_socket()
-
-    if not reset_encryption_secret.is_set() and not reset_encryption_secret.run(args):
-        logger.error(_("The install command failed to reset encryption secret."))
-        return False
-    if not reset_session_secret.is_set() and not reset_session_secret.run(args):
-        logger.error(_("The install command failed to reset session secret."))
-        return False
-    if not reset_admin_password.is_set() and not reset_admin_password.run(args):
-        logger.error(_("The install command failed to reset admin password."))
-        return False
-    if not reset_database_password.is_set() and not reset_database_password.run(args):
-        logger.error(_("The install command failed to reset database password."))
-        return False
-    if not reset_redis_password.is_set() and not reset_redis_password.run(args):
-        logger.error(_("The install command failed to reset Redis password."))
+    if not reset_secrets(args):
         return False
 
     override_conf_dir_path = None

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import pathlib
 import stat
+import subprocess
 from datetime import datetime
 from gettext import gettext as _
 from importlib import resources
@@ -258,6 +259,11 @@ def run(args: argparse.Namespace) -> bool:
                 {"override_conf_dir": args.override_conf_dir},
             )
     write_config_files(override_conf_dir_path)
-    systemctl_reload()
+    try:
+        systemctl_reload()
+    except subprocess.CalledProcessError:
+        logger.error(_("systemctl reload failed unexpectedly. Please check logs."))
+        return False
+
     logger.debug("Finished install command")
     return True

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -5,6 +5,7 @@ import logging
 import pathlib
 import stat
 import subprocess
+import textwrap
 from datetime import datetime
 from gettext import gettext as _
 from importlib import resources
@@ -19,6 +20,17 @@ from quipucordsctl.systemdunitparser import SystemdUnitParser
 
 SYSTEMCTL_USER_RESET_FAILED_CMD = ["systemctl", "--user", "reset-failed"]
 SYSTEMCTL_USER_DAEMON_RELOAD_CMD = ["systemctl", "--user", "daemon-reload"]
+
+INSTALL_SUCCESS_LONG_MESSAGE = _(
+    textwrap.dedent(
+        """
+        Installation completed successfully. Please run the following commands to start the %(server_software_name)s server:
+
+            podman login registry.redhat.io
+            systemctl --user restart %(server_software_package)s-app
+        """  # noqa: E501
+    )
+)
 
 logger = logging.getLogger(__name__)
 
@@ -266,5 +278,12 @@ def run(args: argparse.Namespace) -> bool:
         logger.error(_("systemctl reload failed unexpectedly. Please check logs."))
         return False
 
-    logger.debug("Finished install command")
+    if not args.quiet:
+        print(
+            INSTALL_SUCCESS_LONG_MESSAGE
+            % {
+                "server_software_name": settings.SERVER_SOFTWARE_NAME,
+                "server_software_package": settings.SERVER_SOFTWARE_PACKAGE,
+            },
+        )
     return True

--- a/src/quipucordsctl/commands/reset_admin_password.py
+++ b/src/quipucordsctl/commands/reset_admin_password.py
@@ -22,9 +22,7 @@ def get_help() -> str:
 
 def admin_password_is_set() -> bool:
     """Check if the admin password is already set."""
-    # TODO `podman secret exists PODMAN_SECRET_NAME`
-    # TODO Implement or delete this if we don't actually need it.
-    return False
+    return podman_utils.secret_exists(ADMIN_PASSWORD_PODMAN_SECRET_NAME)
 
 
 def run(args: argparse.Namespace) -> bool:  # noqa: PLR0911

--- a/src/quipucordsctl/commands/reset_admin_password.py
+++ b/src/quipucordsctl/commands/reset_admin_password.py
@@ -20,7 +20,7 @@ def get_help() -> str:
     return _("Reset the admin login password.")
 
 
-def admin_password_is_set() -> bool:
+def is_set() -> bool:
     """Check if the admin password is already set."""
     return podman_utils.secret_exists(ADMIN_PASSWORD_PODMAN_SECRET_NAME)
 

--- a/src/quipucordsctl/commands/reset_database_password.py
+++ b/src/quipucordsctl/commands/reset_database_password.py
@@ -1,0 +1,100 @@
+"""Reset the database password."""
+# TODO Should this command also conditionally restart the server?
+
+import argparse
+import logging
+from gettext import gettext as _
+
+from quipucordsctl import podman_utils, secrets, settings, shell_utils
+
+logger = logging.getLogger(__name__)
+DATABASE_PASSWORD_PODMAN_SECRET_NAME = "quipucords-db-password"  # noqa: S105
+DATABASE_PASSWORD_MIN_LENGTH = 16
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Reset the database password.")
+
+
+def setup_parser(parser: argparse.ArgumentParser) -> None:
+    """Add arguments to this command's argparse subparser."""
+    parser.add_argument(
+        "-p",
+        "--prompt",
+        action="store_true",
+        help=_(
+            "Prompt for custom database password "
+            "(default: no prompt, generate a random value)"
+        ),
+    )
+
+
+def database_password_is_set() -> bool:
+    """Check if the database password is already set."""
+    return podman_utils.secret_exists(DATABASE_PASSWORD_PODMAN_SECRET_NAME)
+
+
+def run(args: argparse.Namespace) -> bool:
+    """
+    Reset the database password.
+
+    * If secret already exists, warn and confirm before proceeding.
+    * If "--prompt" was set, warn and confirm before proceeding.
+    * Prompt for new value or generate a value randomly.
+    * If secret already exists, delete it.
+    * Create new secret.
+    * Return True if everything succeeds, or False if user declines any prompt.
+    """
+    if should_replace := podman_utils.secret_exists(
+        DATABASE_PASSWORD_PODMAN_SECRET_NAME
+    ):
+        logger.warning(
+            _(
+                "The database password already exists. "
+                "Resetting the database password to a new value "
+                "may result in data loss if you have already installed "
+                "and run %(SERVER_SOFTWARE_NAME)s on this system."
+            ),
+            {"SERVER_SOFTWARE_NAME": settings.SERVER_SOFTWARE_NAME},
+        )
+        if not shell_utils.confirm(
+            _("Are you sure you want to replace the existing database password? [y/n] ")
+        ):
+            return False
+    if getattr(args, "prompt", False):
+        logger.warning(
+            _(
+                "You should only manually reset the database password if you "
+                "understand how it it used and you are addressing a specific issue. "
+                "We strongly recommend using the automatically generated database "
+                "password instead of manually entering one."
+            )
+        )
+        if not shell_utils.confirm(
+            _("Are you sure you want to manually reset the database password? [y/n] ")
+        ):
+            return False
+        if not (
+            new_secret := secrets.prompt_secret(
+                _("database password"), min_length=DATABASE_PASSWORD_MIN_LENGTH
+            )
+        ):
+            logger.error(_("The database password was not updated."))
+            return False
+    else:
+        new_secret = secrets.generate_random_secret(DATABASE_PASSWORD_MIN_LENGTH)
+        logger.info(
+            _(
+                "New value for podman secret %(PODMAN_SECRET_NAME)s "
+                "was randomly generated."
+            ),
+            {"PODMAN_SECRET_NAME": DATABASE_PASSWORD_PODMAN_SECRET_NAME},
+        )
+    if not podman_utils.set_secret(
+        DATABASE_PASSWORD_PODMAN_SECRET_NAME, new_secret, should_replace
+    ):
+        logger.error(_("The database password was not updated."))
+        return False
+    logger.debug(_("The database password was successfully updated."))
+    return True

--- a/src/quipucordsctl/commands/reset_database_password.py
+++ b/src/quipucordsctl/commands/reset_database_password.py
@@ -30,7 +30,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def database_password_is_set() -> bool:
+def is_set() -> bool:
     """Check if the database password is already set."""
     return podman_utils.secret_exists(DATABASE_PASSWORD_PODMAN_SECRET_NAME)
 

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -12,7 +12,7 @@ from gettext import gettext as _
 from quipucordsctl import podman_utils, secrets, settings, shell_utils
 
 logger = logging.getLogger(__name__)
-ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME = "quipucords-django-secret-key"  # noqa: S105 E501
+ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME = "quipucords-encryption-secret-key"  # noqa: S105 E501
 ENCRYPTION_SECRET_KEY_MIN_LENGTH = 64
 
 

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -36,8 +36,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
 
 def encryption_secret_is_set() -> bool:
     """Check if the encryption secret key is already set."""
-    # TODO `podman secret exists quipucords-encryption-secret-key`
-    return False
+    return podman_utils.secret_exists(ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME)
 
 
 def run(args: argparse.Namespace) -> bool:

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -69,7 +69,7 @@ def run(args: argparse.Namespace) -> bool:
             )
         ):
             return False
-    if args.prompt:
+    if getattr(args, "prompt", False):
         logger.warning(
             _(
                 "You should only manually reset the encryption secret key "

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -34,7 +34,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def encryption_secret_is_set() -> bool:
+def is_set() -> bool:
     """Check if the encryption secret key is already set."""
     return podman_utils.secret_exists(ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME)
 

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -12,7 +12,7 @@ from gettext import gettext as _
 from quipucordsctl import podman_utils, secrets, settings, shell_utils
 
 logger = logging.getLogger(__name__)
-ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME = "quipucords-encryption-secret-key"  # noqa: S105 E501
+ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME = "quipucords-django-secret-key"  # noqa: S105 E501
 ENCRYPTION_SECRET_KEY_MIN_LENGTH = 64
 
 

--- a/src/quipucordsctl/commands/reset_redis_password.py
+++ b/src/quipucordsctl/commands/reset_redis_password.py
@@ -35,7 +35,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def redis_password_is_set() -> bool:
+def is_set() -> bool:
     """Check if the Redis password is already set."""
     return podman_utils.secret_exists(REDIS_PASSWORD_PODMAN_SECRET_NAME)
 

--- a/src/quipucordsctl/commands/reset_redis_password.py
+++ b/src/quipucordsctl/commands/reset_redis_password.py
@@ -1,0 +1,85 @@
+"""
+Reset the Redis password.
+
+The Redis password is used for short-lived cryptographic signing
+of session data and related tokens.
+"""
+# TODO Should this command also conditionally restart the server?
+
+import argparse
+import logging
+from gettext import gettext as _
+
+from quipucordsctl import podman_utils, secrets, shell_utils
+
+logger = logging.getLogger(__name__)
+REDIS_PASSWORD_PODMAN_SECRET_NAME = "quipucords-redis-password"  # noqa: S105
+SECRET_MIN_LENGTH = 64
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Reset the Redis password.")
+
+
+def setup_parser(parser: argparse.ArgumentParser) -> None:
+    """Add arguments to this command's argparse subparser."""
+    parser.add_argument(
+        "-p",
+        "--prompt",
+        action="store_true",
+        help=_(
+            "Prompt for custom Redis password "
+            "(default: no prompt, generate a random value)"
+        ),
+    )
+
+
+def redis_password_is_set() -> bool:
+    """Check if the Redis password is already set."""
+    return podman_utils.secret_exists(REDIS_PASSWORD_PODMAN_SECRET_NAME)
+
+
+def run(args: argparse.Namespace) -> bool:
+    """
+    Reset the server Redis password.
+
+    * Prompt for new value or generate a value randomly.
+    * If secret already exists, delete it.
+    * Create new secret.
+    * Return True if everything succeeds, or False if user declines any prompt.
+    """
+    if getattr(args, "prompt", False):
+        logger.warning(
+            _(
+                "You should only manually reset the Redis password if you "
+                "understand how it it used and you are addressing a specific issue. "
+                "We strongly recommend using the automatically generated Redis "
+                "password instead of manually entering one."
+            )
+        )
+        if not shell_utils.confirm(
+            _("Are you sure you want to manually reset the Redis password? [y/n] ")
+        ):
+            return False
+        if not (
+            new_secret := secrets.prompt_secret(
+                _("Redis password"), min_length=SECRET_MIN_LENGTH
+            )
+        ):
+            logger.error(_("The Redis password was not updated."))
+            return False
+    else:
+        new_secret = secrets.generate_random_secret(SECRET_MIN_LENGTH)
+        logger.info(
+            _(
+                "New value for podman secret %(PODMAN_SECRET_NAME)s "
+                "was randomly generated."
+            ),
+            {"PODMAN_SECRET_NAME": REDIS_PASSWORD_PODMAN_SECRET_NAME},
+        )
+    if not podman_utils.set_secret(REDIS_PASSWORD_PODMAN_SECRET_NAME, new_secret):
+        logger.error(_("The Redis password was not updated."))
+        return False
+    logger.debug(_("The Redis password was successfully updated."))
+    return True

--- a/src/quipucordsctl/commands/reset_session_secret.py
+++ b/src/quipucordsctl/commands/reset_session_secret.py
@@ -37,8 +37,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
 
 def session_secret_is_set() -> bool:
     """Check if the session secret key is already set."""
-    # TODO `podman secret exists quipucords-session-secret-key`
-    return False
+    return podman_utils.secret_exists(SESSION_SECRET_PODMAN_SECRET_NAME)
 
 
 def run(args: argparse.Namespace) -> bool:

--- a/src/quipucordsctl/commands/reset_session_secret.py
+++ b/src/quipucordsctl/commands/reset_session_secret.py
@@ -35,7 +35,7 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def session_secret_is_set() -> bool:
+def is_set() -> bool:
     """Check if the session secret key is already set."""
     return podman_utils.secret_exists(SESSION_SECRET_PODMAN_SECRET_NAME)
 

--- a/src/quipucordsctl/commands/reset_session_secret.py
+++ b/src/quipucordsctl/commands/reset_session_secret.py
@@ -49,7 +49,7 @@ def run(args: argparse.Namespace) -> bool:
     * Create new secret.
     * Return True if everything succeeds, or False if user declines any prompt.
     """
-    if args.prompt:
+    if getattr(args, "prompt", False):
         logger.warning(
             _(
                 "You should only manually reset the session secret key if you "

--- a/src/quipucordsctl/secrets.py
+++ b/src/quipucordsctl/secrets.py
@@ -46,7 +46,7 @@ def generate_random_secret(length: int) -> str:
             # It's unlikely but possible for token_urlsafe to generate
             # a value that does not pass our check_secret requirements.
             # Loop and try again just to be safe.
-            if check_secret(new_secret):
+            if check_secret(new_secret, min_length=length):
                 return new_secret
 
 

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -1,6 +1,5 @@
 """Global configuration settings for quipucordsctl."""
 
-import importlib.resources as pkg_resources
 import logging
 import pathlib
 
@@ -21,6 +20,23 @@ SERVER_DATA_SUBDIRS = {
     for data_dir in ("data", "db", "log", "sshkeys")
 }
 
-_templates = pathlib.Path(str(pkg_resources.files("quipucordsctl"))) / "templates"
-SYSTEMD_UNITS_TEMPLATES_DIR = _templates / "config"
-ENV_TEMPLATES_DIR = _templates / "env"
+# "Explicit is better than implicit." - PEP 20
+# Do not glob the template directories. Use these definitions.
+TEMPLATE_SYSTEMD_UNITS_RESOURCE_PATH = "templates/config"
+TEMPLATE_SYSTEMD_UNITS_FILENAMES = (
+    "quipucords.network",
+    "quipucords-app.container",
+    "quipucords-celery-worker.container",
+    "quipucords-db.container",
+    "quipucords-redis.container",
+    "quipucords-server.container",
+)
+TEMPLATE_SERVER_ENV_RESOURCE_PATH = "templates/env"
+TEMPLATE_SERVER_ENV_FILENAMES = (
+    "env-ansible.env",
+    "env-app.env",
+    "env-celery-worker.env",
+    "env-db.env",
+    "env-redis.env",
+    "env-server.env",
+)

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -17,7 +17,7 @@ SERVER_DATA_DIR = _home / f".local/share/{SERVER_SOFTWARE_PACKAGE}"
 SYSTEMD_UNITS_DIR = _home / ".config/containers/systemd"
 SERVER_DATA_SUBDIRS = {
     data_dir: SERVER_DATA_DIR / data_dir
-    for data_dir in ("data", "db", "log", "sshkeys")
+    for data_dir in ("certs", "data", "db", "log", "sshkeys")
 }
 
 # "Explicit is better than implicit." - PEP 20

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -16,6 +16,10 @@ _home = pathlib.Path.home()
 SERVER_ENV_DIR = _home / f".config/{SERVER_SOFTWARE_PACKAGE}/env"
 SERVER_DATA_DIR = _home / f".local/share/{SERVER_SOFTWARE_PACKAGE}"
 SYSTEMD_UNITS_DIR = _home / ".config/containers/systemd"
+SERVER_DATA_SUBDIRS = {
+    data_dir: SERVER_DATA_DIR / data_dir
+    for data_dir in ("data", "db", "log", "sshkeys")
+}
 
 _templates = pathlib.Path(str(pkg_resources.files("quipucordsctl"))) / "templates"
 SYSTEMD_UNITS_TEMPLATES_DIR = _templates / "config"

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -1,8 +1,10 @@
 """Utilities for interacting with user's shell and external programs."""
 
+import logging
 import subprocess
-import sys
 from gettext import gettext as _
+
+logger = logging.getLogger(__name__)
 
 
 def confirm(prompt: str | None = None) -> bool:
@@ -37,9 +39,9 @@ def run_command(command: list[str]) -> tuple[str, str, int]:
 
     stdout, stderr = stdout.strip(), stderr.strip()
     if stdout:
-        print(f"stdout: {stdout}")
+        logger.info(stdout)
     if stderr:
-        print(stderr, file=sys.stderr)
+        logger.error(stderr)
     if exit_code != 0:
         raise subprocess.CalledProcessError(exit_code, command)
 

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -47,14 +47,14 @@ def run_command(command: list[str], *, quiet=False) -> tuple[str, str, int]:
         )
         raise error
 
-    stdout, stderr = stdout.strip(), stderr.strip()
-    # If the command failed, log the output despite quite arg.
-    if stdout and (not quiet or exit_code != 0):
-        for line in stdout.splitlines():
-            logger.debug(line)
-    if stderr and (not quiet or exit_code != 0):
-        for line in stderr.splitlines():
-            logger.warning(line)
+    # make stdout and stderr noisier if the process did not exit cleanly
+    stdout_logger = logger.debug if exit_code == 0 else logger.info
+    stderr_logger = logger.debug if exit_code == 0 else logger.error
+    for line in stdout.strip().splitlines():
+        stdout_logger(line)
+    for line in stderr.strip().splitlines():
+        stderr_logger(line)
+
     if exit_code != 0:
         logger.error(
             _(

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -22,29 +22,39 @@ def confirm(prompt: str | None = None) -> bool:
     return False
 
 
-def run_command(command: list[str]) -> tuple[str, str, int]:
+def run_command(command: list[str], *, quiet=False) -> tuple[str, str, int]:
     """Run an external program."""
     logger.debug(
         _("Invoking subprocess with arguments %(command)s"), {"command": command}
     )
-    process = subprocess.Popen(
-        args=command,  # a list like ["systemctl", "--user", "reset-failed"]
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,  # we always expect input/output text, not byte strings
-    )
+    try:
+        process = subprocess.Popen(
+            args=command,  # a list like ["systemctl", "--user", "reset-failed"]
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,  # we always expect input/output text, not byte strings
+        )
 
-    # TODO figure out how we want to handle stdout/stderr
-    # TODO maybe support "realtime" stdout display instead of capturing at the end
-    # TODO should these *always* go to our stdout/stderr or use the logger?
-    stdout, stderr = process.communicate()
-    exit_code = process.returncode
+        # TODO figure out how we want to handle stdout/stderr
+        # TODO maybe support "realtime" stdout display instead of capturing at the end
+        # TODO should these *always* go to our stdout/stderr or use the logger?
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+    except Exception as error:
+        logger.error(
+            _("Subprocess with arguments %(command)s failed due to unexpected error."),
+            {"command": command},
+        )
+        raise error
 
     stdout, stderr = stdout.strip(), stderr.strip()
-    if stdout:
-        logger.info(stdout)
-    if stderr:
-        logger.error(stderr)
+    # If the command failed, log the output despite quite arg.
+    if stdout and (not quiet or exit_code != 0):
+        for line in stdout.splitlines():
+            logger.debug(line)
+    if stderr and (not quiet or exit_code != 0):
+        for line in stderr.splitlines():
+            logger.warning(line)
     if exit_code != 0:
         logger.error(
             _(
@@ -53,6 +63,6 @@ def run_command(command: list[str]) -> tuple[str, str, int]:
             ),
             {"command": command, "exit_code": exit_code},
         )
-        raise subprocess.CalledProcessError(exit_code, command)
+        raise subprocess.CalledProcessError(exit_code, command, stdout, stderr)
 
     return stdout, stderr, exit_code

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -24,6 +24,9 @@ def confirm(prompt: str | None = None) -> bool:
 
 def run_command(command: list[str]) -> tuple[str, str, int]:
     """Run an external program."""
+    logger.debug(
+        _("Invoking subprocess with arguments %(command)s"), {"command": command}
+    )
     process = subprocess.Popen(
         args=command,  # a list like ["systemctl", "--user", "reset-failed"]
         stdout=subprocess.PIPE,
@@ -43,6 +46,13 @@ def run_command(command: list[str]) -> tuple[str, str, int]:
     if stderr:
         logger.error(stderr)
     if exit_code != 0:
+        logger.error(
+            _(
+                "Subprocess with arguments %(command)s failed "
+                "with exit code %(exit_code)s"
+            ),
+            {"command": command, "exit_code": exit_code},
+        )
         raise subprocess.CalledProcessError(exit_code, command)
 
     return stdout, stderr, exit_code

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -14,9 +14,9 @@ def confirm(prompt: str | None = None) -> bool:
         prompt = _("Do you want to continue? [y/n] ")
     while user_input is None:
         user_input = input(prompt).lower()
-        if user_input == "y":
+        if user_input == _("y"):
             return True
-        elif user_input != "n":
+        elif user_input != _("n"):
             print(_("Please answer with 'y' or 'n'."))
             user_input = None
     return False

--- a/src/quipucordsctl/systemdunitparser/__init__.py
+++ b/src/quipucordsctl/systemdunitparser/__init__.py
@@ -1,0 +1,202 @@
+import configparser
+import sys
+
+__author__ = 'sgallagh'
+
+"""
+Sections of this parser are adapted from:
+
+http://stackoverflow.com/questions/13921323/handling-duplicate-keys-with-configparser
+LICENSE: https://creativecommons.org/licenses/by-sa/3.0/ (CC-BY-SA 3.0)
+Original Author: Praetorian on StackExchange
+"""
+
+
+class SystemdUnitParser(configparser.RawConfigParser):
+    """ConfigParser allowing duplicate keys. Values are stored in a list"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, empty_lines_in_values=False, strict=False, **kwargs)
+        self.optionxform = lambda option: option
+
+        self._inline_comment_prefixes = kwargs.get('inline_comment_prefixes', None)
+        self._comment_prefixes = kwargs.get('comment_prefixes', ('#', ';'))
+
+    def _get_inline_prefixes(self):
+        # Fix for newer cython
+        if hasattr(self, '_inline_comment_prefixes'):
+            return self._inline_comment_prefixes or ()
+        elif hasattr(self, '_prefixes'):
+            return self._prefixes.inline or ()
+        return ()
+        
+    def _get_comment_prefixes(self):
+        if hasattr(self, '_comment_prefixes'):
+            return self._comment_prefixes or ()
+        elif hasattr(self, '_prefixes'):
+            return self._prefixes.full or ()
+        return ()
+
+    def _read(self, fp, fpname):
+        """Parse a sectioned configuration file.
+
+        Each section in a configuration file contains a header, indicated by
+        a name in square brackets (`[]'), plus key/value options, indicated by
+        `name' and `value' delimited with a specific substring (`=' or `:' by
+        default).
+
+        Values can span multiple lines, as long as they are indented deeper
+        than the first line of the value. Depending on the parser's mode, blank
+        lines may be treated as parts of multiline values or ignored.
+
+        Configuration files may include comments, prefixed by specific
+        characters (`#' and `;' by default). Comments may appear on their own
+        in an otherwise empty line or may be entered in lines holding values or
+        section names.
+        """
+        elements_added = set()
+        cursect = None  # None, or a dictionary
+        sectname = None
+        optname = None
+        lineno = 0
+        indent_level = 0
+        e = None  # None, or an exception
+        for lineno, line in enumerate(fp, start=1):
+            comment_start = sys.maxsize
+            # strip inline comments
+            inline_prefixes = {p: -1 for p in self._get_inline_prefixes()}
+            while comment_start == sys.maxsize and inline_prefixes:
+                next_prefixes = {}
+                for prefix, index in inline_prefixes.items():
+                    index = line.find(prefix, index + 1)
+                    if index == -1:
+                        continue
+                    next_prefixes[prefix] = index
+                    if index == 0 or (index > 0 and line[index - 1].isspace()):
+                        comment_start = min(comment_start, index)
+                inline_prefixes = next_prefixes
+            # strip full line comments
+            for prefix in self._get_comment_prefixes():
+                if line.strip().startswith(prefix):
+                    comment_start = 0
+                    break
+            if comment_start == sys.maxsize:
+                comment_start = None
+            value = line[:comment_start].strip()
+            if not value:
+                if self._empty_lines_in_values:
+                    # add empty line to the value, but only if there was no
+                    # comment on the line
+                    if (comment_start is None and
+                                cursect is not None and
+                            optname and
+                                cursect[optname] is not None):
+                        cursect[optname].append('')  # newlines added at join
+                else:
+                    # empty line marks end of value
+                    indent_level = sys.maxsize
+                continue
+            # continuation line?
+            first_nonspace = self.NONSPACECRE.search(line)
+            cur_indent_level = first_nonspace.start() if first_nonspace else 0
+            if (cursect is not None and optname and
+                        cur_indent_level > indent_level):
+                cursect[optname].append(value)
+            # a section header or option header?
+            else:
+                indent_level = cur_indent_level
+                # is it a section header?
+                mo = self.SECTCRE.match(value)
+                if mo:
+                    sectname = mo.group('header')
+                    if sectname in self._sections:
+                        cursect = self._sections[sectname]
+                        elements_added.add(sectname)
+                    elif sectname == self.default_section:
+                        cursect = self._defaults
+                    else:
+                        cursect = self._dict()
+                        self._sections[sectname] = cursect
+                        self._proxies[sectname] = configparser.SectionProxy(self, sectname)
+                        elements_added.add(sectname)
+                    # So sections can't start with a continuation line
+                    optname = None
+                # no section header in the file?
+                elif cursect is None:
+                    raise configparser.MissingSectionHeaderError(fpname, lineno, line)
+                # an option line?
+                else:
+                    mo = self._optcre.match(value)
+                    if mo:
+                        optname, vi, optval = mo.group('option', 'vi', 'value')
+                        if not optname:
+                            e = self._handle_error(e, fpname, lineno, line)
+                        optname = self.optionxform(optname.rstrip())
+                        elements_added.add((sectname, optname))
+                        # This check is fine because the OPTCRE cannot
+                        # match if it would set optval to None
+                        if optval is not None:
+                            optval = optval.strip()
+                            # Check if this optname already exists
+                            if (optname in cursect) and (cursect[optname] is not None):
+                                # If it does, convert it to a tuple if it isn't already one
+                                if not isinstance(cursect[optname], tuple):
+                                    cursect[optname] = tuple(cursect[optname])
+                                cursect[optname] = cursect[optname] + tuple([optval])
+                            else:
+                                cursect[optname] = [optval]
+                        else:
+                            # valueless option handling
+                            cursect[optname] = None
+                    else:
+                        # a non-fatal parsing error occurred. set up the
+                        # exception but keep going. the exception will be
+                        # raised at the end of the file and will contain a
+                        # list of all bogus lines
+                        e = self._handle_error(e, fpname, lineno, line)
+        # if any parsing errors occurred, raise an exception
+        if e:
+            raise e
+        self._join_multiline_values()
+
+    def _validate_value_types(self, *, section="", option="", value=""):
+        """Raises a TypeError for non-string values.
+
+        The only legal non-string value if we allow valueless
+        options is None, so we need to check if the value is a
+        string if:
+        - we do not allow valueless options, or
+        - we allow valueless options but the value is not Noneconfigparser.RawConfigParser
+
+        For compatibility reasons this method is not used in classic set()
+        for RawConfigParsers. It is invoked in every case for mapping protocol
+        access and in ConfigParser.set().
+        """
+        if not isinstance(section, str):
+            raise TypeError("section names must be strings")
+        if not isinstance(option, str):
+            raise TypeError("option keys must be strings")
+        if not self._allow_no_value or value:
+            if not isinstance(value, str) and not isinstance(value, tuple):
+                raise TypeError("option values must be strings or a tuple of strings")
+
+    # Write out duplicate keys with their values
+    def _write_section(self, fp, section_name, section_items, delimiter):
+        """Write a single section to the specified `fp'."""
+        fp.write("[{}]\n".format(section_name))
+        for key, vals in section_items:
+            vals = self._interpolation.before_write(self, section_name, key,
+                                                    vals)
+            if not isinstance(vals, tuple):
+                vals = tuple([vals])
+            for value in vals:
+                if value is not None or not self._allow_no_value:
+                    value = delimiter + str(value).replace('\n', '\n\t')
+                else:
+                    value = ""
+                fp.write("{}{}\n".format(key, value))
+        fp.write("\n")
+
+    # Default to not creating spaces around the delimiter
+    def write(self, fp, space_around_delimiters=False):
+        configparser.RawConfigParser.write(self, fp, space_around_delimiters)

--- a/src/quipucordsctl/systemdunitparser/__init__.py
+++ b/src/quipucordsctl/systemdunitparser/__init__.py
@@ -1,7 +1,7 @@
 import configparser
 import sys
 
-__author__ = 'sgallagh'
+__author__ = "sgallagh"
 
 """
 Sections of this parser are adapted from:
@@ -13,27 +13,27 @@ Original Author: Praetorian on StackExchange
 
 
 class SystemdUnitParser(configparser.RawConfigParser):
-    """ConfigParser allowing duplicate keys. Values are stored in a list"""
+    """ConfigParser allowing duplicate keys. Values are stored in a list."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, empty_lines_in_values=False, strict=False, **kwargs)
         self.optionxform = lambda option: option
 
-        self._inline_comment_prefixes = kwargs.get('inline_comment_prefixes', None)
-        self._comment_prefixes = kwargs.get('comment_prefixes', ('#', ';'))
+        self._inline_comment_prefixes = kwargs.get("inline_comment_prefixes", None)
+        self._comment_prefixes = kwargs.get("comment_prefixes", ("#", ";"))
 
     def _get_inline_prefixes(self):
         # Fix for newer cython
-        if hasattr(self, '_inline_comment_prefixes'):
+        if hasattr(self, "_inline_comment_prefixes"):
             return self._inline_comment_prefixes or ()
-        elif hasattr(self, '_prefixes'):
+        elif hasattr(self, "_prefixes"):
             return self._prefixes.inline or ()
         return ()
-        
+
     def _get_comment_prefixes(self):
-        if hasattr(self, '_comment_prefixes'):
+        if hasattr(self, "_comment_prefixes"):
             return self._comment_prefixes or ()
-        elif hasattr(self, '_prefixes'):
+        elif hasattr(self, "_prefixes"):
             return self._prefixes.full or ()
         return ()
 
@@ -87,11 +87,13 @@ class SystemdUnitParser(configparser.RawConfigParser):
                 if self._empty_lines_in_values:
                     # add empty line to the value, but only if there was no
                     # comment on the line
-                    if (comment_start is None and
-                                cursect is not None and
-                            optname and
-                                cursect[optname] is not None):
-                        cursect[optname].append('')  # newlines added at join
+                    if (
+                        comment_start is None
+                        and cursect is not None
+                        and optname
+                        and cursect[optname] is not None
+                    ):
+                        cursect[optname].append("")  # newlines added at join
                 else:
                     # empty line marks end of value
                     indent_level = sys.maxsize
@@ -99,8 +101,7 @@ class SystemdUnitParser(configparser.RawConfigParser):
             # continuation line?
             first_nonspace = self.NONSPACECRE.search(line)
             cur_indent_level = first_nonspace.start() if first_nonspace else 0
-            if (cursect is not None and optname and
-                        cur_indent_level > indent_level):
+            if cursect is not None and optname and cur_indent_level > indent_level:
                 cursect[optname].append(value)
             # a section header or option header?
             else:
@@ -108,7 +109,7 @@ class SystemdUnitParser(configparser.RawConfigParser):
                 # is it a section header?
                 mo = self.SECTCRE.match(value)
                 if mo:
-                    sectname = mo.group('header')
+                    sectname = mo.group("header")
                     if sectname in self._sections:
                         cursect = self._sections[sectname]
                         elements_added.add(sectname)
@@ -117,7 +118,9 @@ class SystemdUnitParser(configparser.RawConfigParser):
                     else:
                         cursect = self._dict()
                         self._sections[sectname] = cursect
-                        self._proxies[sectname] = configparser.SectionProxy(self, sectname)
+                        self._proxies[sectname] = configparser.SectionProxy(
+                            self, sectname
+                        )
                         elements_added.add(sectname)
                     # So sections can't start with a continuation line
                     optname = None
@@ -128,7 +131,7 @@ class SystemdUnitParser(configparser.RawConfigParser):
                 else:
                     mo = self._optcre.match(value)
                     if mo:
-                        optname, vi, optval = mo.group('option', 'vi', 'value')
+                        optname, vi, optval = mo.group("option", "vi", "value")
                         if not optname:
                             e = self._handle_error(e, fpname, lineno, line)
                         optname = self.optionxform(optname.rstrip())
@@ -185,13 +188,12 @@ class SystemdUnitParser(configparser.RawConfigParser):
         """Write a single section to the specified `fp'."""
         fp.write("[{}]\n".format(section_name))
         for key, vals in section_items:
-            vals = self._interpolation.before_write(self, section_name, key,
-                                                    vals)
+            vals = self._interpolation.before_write(self, section_name, key, vals)
             if not isinstance(vals, tuple):
                 vals = tuple([vals])
             for value in vals:
                 if value is not None or not self._allow_no_value:
-                    value = delimiter + str(value).replace('\n', '\n\t')
+                    value = delimiter + str(value).replace("\n", "\n\t")
                 else:
                     value = ""
                 fp.write("{}{}\n".format(key, value))

--- a/src/quipucordsctl/templates/config/quipucords-app.container
+++ b/src/quipucordsctl/templates/config/quipucords-app.container
@@ -1,10 +1,10 @@
 [Unit]
 Description=Quipucords App
 Requires=podman.socket
-Wants=quipucords-db.service
-Wants=quipucords-redis.service
-Wants=quipucords-celery-worker.service
-Wants=quipucords-server.service
+Requires=quipucords-db.service
+Requires=quipucords-redis.service
+Requires=quipucords-celery-worker.service
+Requires=quipucords-server.service
 After=quipucords-server.service
 
 [Container]
@@ -16,10 +16,11 @@ EnvironmentFile=%h/.config/quipucords/env/env-app.env
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/certs:/opt/app-root/certs:z
 Network=quipucords.network
+LogDriver=journald
 # Since we could write self-generated keys to the shared certs
 # volume and write nginx logs to the common log volume,
 # let's make sure we map the nginx user to the host's user.
-UserNS=keep-id:uid=1001,gid=1001
+UserNS=keep-id:uid=1001
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0

--- a/src/quipucordsctl/templates/config/quipucords-celery-worker.container
+++ b/src/quipucordsctl/templates/config/quipucords-celery-worker.container
@@ -11,16 +11,24 @@ EnvironmentFile=%h/.config/quipucords/env/env-db.env
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 EnvironmentFile=%h/.config/quipucords/env/env-ansible.env
 EnvironmentFile=%h/.config/quipucords/env/env-celery-worker.env
-Secret=quipucords-encryption-secret-key,type=env,target=QUIPUCORDS_ENCRYPTION_SECRET_KEY
-Secret=quipucords-session-secret-key,type=env,target=QUIPUCORDS_SESSION_SECRET_KEY
+Secret=quipucords-django-secret-key,type=env,target=DJANGO_SECRET_KEY
+Secret=quipucords-db-password,type=env,target=QUIPUCORDS_DBMS_PASSWORD
+Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Exec=/bin/sh -c /deploy/entrypoint_celery_worker.sh
 Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+LogDriver=journald
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0
+# Konflux requires non-root users in container images; for this reason, quipucords-server
+# versions above 1.12.1 shall use user 1001, regardless of being released through Konflux
+# or Brew, to accommodate this change.
+# Mounted volumes are always mapped to root on SELinux, so we need to use UserNS config to
+# set the ownership correctly.
+UserNS=keep-id:uid=1001
 
 [Service]
 TimeoutStartSec=300

--- a/src/quipucordsctl/templates/config/quipucords-celery-worker.container
+++ b/src/quipucordsctl/templates/config/quipucords-celery-worker.container
@@ -11,7 +11,8 @@ EnvironmentFile=%h/.config/quipucords/env/env-db.env
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 EnvironmentFile=%h/.config/quipucords/env/env-ansible.env
 EnvironmentFile=%h/.config/quipucords/env/env-celery-worker.env
-Secret=quipucords-django-secret-key,type=env,target=DJANGO_SECRET_KEY
+Secret=quipucords-session-secret-key,type=env,target=QUIPUCORDS_SESSION_SECRET_KEY
+Secret=quipucords-encryption-secret-key,type=env,target=QUIPUCORDS_ENCRYPTION_SECRET_KEY
 Secret=quipucords-db-password,type=env,target=QUIPUCORDS_DBMS_PASSWORD
 Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Exec=/bin/sh -c /deploy/entrypoint_celery_worker.sh

--- a/src/quipucordsctl/templates/config/quipucords-db.container
+++ b/src/quipucordsctl/templates/config/quipucords-db.container
@@ -8,10 +8,11 @@ ContainerName=quipucords-db
 Image=registry.redhat.io/rhel9/postgresql-15:latest
 ExposeHostPort=5432
 Environment=POSTGRESQL_USER=qpc
-Environment=POSTGRESQL_PASSWORD=qpc
 Environment=POSTGRESQL_DATABASE=qpc
 Volume=%h/.local/share/quipucords/db:/var/lib/pgsql/data:z
+Secret=quipucords-db-password,type=env,target=POSTGRESQL_PASSWORD
 Network=quipucords.network
+LogDriver=journald
 # for some reason podman default user mapping won't map host user to postgres container uid (26)[1]
 # (maybe due to fix-permission script it executes later on [2]), so we fix that setting this up with
 # UserNS.

--- a/src/quipucordsctl/templates/config/quipucords-redis.container
+++ b/src/quipucordsctl/templates/config/quipucords-redis.container
@@ -5,9 +5,10 @@ PartOf=quipucords-app.service
 
 [Container]
 ContainerName=quipucords-redis
-Image=registry.redhat.io/rhel9/redis-6:latest
+Image=registry.redhat.io/rhel9/redis-7:latest
 ExposeHostPort=6379
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
+Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Network=quipucords.network
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.

--- a/src/quipucordsctl/templates/config/quipucords-server.container
+++ b/src/quipucordsctl/templates/config/quipucords-server.container
@@ -14,7 +14,8 @@ EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 EnvironmentFile=%h/.config/quipucords/env/env-ansible.env
 EnvironmentFile=%h/.config/quipucords/env/env-server.env
 Secret=quipucords-server-password,type=env,target=QUIPUCORDS_SERVER_PASSWORD
-Secret=quipucords-django-secret-key,type=env,target=DJANGO_SECRET_KEY
+Secret=quipucords-session-secret-key,type=env,target=QUIPUCORDS_SESSION_SECRET_KEY
+Secret=quipucords-encryption-secret-key,type=env,target=QUIPUCORDS_ENCRYPTION_SECRET_KEY
 Secret=quipucords-db-password,type=env,target=QUIPUCORDS_DBMS_PASSWORD
 Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Volume=%h/.local/share/quipucords/data:/var/data:z

--- a/src/quipucordsctl/templates/config/quipucords-server.container
+++ b/src/quipucordsctl/templates/config/quipucords-server.container
@@ -14,15 +14,23 @@ EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 EnvironmentFile=%h/.config/quipucords/env/env-ansible.env
 EnvironmentFile=%h/.config/quipucords/env/env-server.env
 Secret=quipucords-server-password,type=env,target=QUIPUCORDS_SERVER_PASSWORD
-Secret=quipucords-encryption-secret-key,type=env,target=QUIPUCORDS_ENCRYPTION_SECRET_KEY
-Secret=quipucords-session-secret-key,type=env,target=QUIPUCORDS_SESSION_SECRET_KEY
+Secret=quipucords-django-secret-key,type=env,target=DJANGO_SECRET_KEY
+Secret=quipucords-db-password,type=env,target=QUIPUCORDS_DBMS_PASSWORD
+Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+LogDriver=journald
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0
+# Konflux requires non-root users in container images; for this reason, quipucords-server
+# versions above 1.12.1 shall use user 1001, regardless of being released through Konflux
+# or Brew, to accommodate this change.
+# Mounted volumes are always mapped to root on SELinux, so we need to use UserNS config to
+# set the ownership correctly.
+UserNS=keep-id:uid=1001
 
 [Service]
 Restart=always

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -72,24 +72,15 @@ def test_install_run(
     env_dir = temp_config_directories["SERVER_ENV_DIR"]
     systemd_dir = temp_config_directories["SYSTEMD_UNITS_DIR"]
     with (
-        mock.patch.object(
-            install, "reset_encryption_secret"
-        ) as reset_encryption_secret,
-        mock.patch.object(install, "reset_session_secret") as reset_session_secret,
-        mock.patch.object(install, "reset_admin_password") as reset_admin_password,
-        mock.patch.object(
-            install, "reset_database_password"
-        ) as reset_database_password,
-        mock.patch.object(install, "reset_redis_password") as reset_redis_password,
+        mock.patch.object(install, "reset_secrets") as reset_secrets,
         mock.patch.object(install, "systemctl_reload") as systemctl_reload,
     ):
-        reset_encryption_secret.is_set.return_value = False
-        reset_session_secret.is_set.return_value = False
-        reset_admin_password.is_set.return_value = False
-        reset_database_password.is_set.return_value = False
-        reset_redis_password.is_set.return_value = False
+        reset_secrets.return_value = True
 
         install.run(mock_args)
+
+        reset_secrets.assert_called_once_with(mock_args)
+        systemctl_reload.assert_called_once()
 
         # Spot-check only a few paths that should now exist.
         assert (data_dir / "data").is_dir()
@@ -110,12 +101,35 @@ def test_install_run(
         parser.read(str((systemd_dir / "quipucords-app.container")))
         assert parser[unit_override_section][unit_override_key] == unit_override_value
 
-        reset_encryption_secret.run.assert_called_once()
-        reset_session_secret.run.assert_called_once()
-        reset_admin_password.run.assert_called_once()
-        reset_database_password.run.assert_called_once()
-        reset_redis_password.run.assert_called_once()
-        systemctl_reload.assert_called_once()
+
+def test_reset_secrets():
+    """Test the installer.reset_secrets helper function."""
+    mock_args = mock.Mock()
+
+    with (
+        mock.patch.object(
+            install, "reset_encryption_secret"
+        ) as reset_encryption_secret,
+        mock.patch.object(install, "reset_session_secret") as reset_session_secret,
+        mock.patch.object(install, "reset_admin_password") as reset_admin_password,
+        mock.patch.object(
+            install, "reset_database_password"
+        ) as reset_database_password,
+        mock.patch.object(install, "reset_redis_password") as reset_redis_password,
+    ):
+        reset_encryption_secret.is_set.return_value = False
+        reset_session_secret.is_set.return_value = False
+        reset_admin_password.is_set.return_value = False
+        reset_database_password.is_set.return_value = False
+        reset_redis_password.is_set.return_value = False
+
+        install.reset_secrets(mock_args)
+
+        reset_encryption_secret.run.assert_called_once_with(mock_args)
+        reset_session_secret.run.assert_called_once_with(mock_args)
+        reset_admin_password.run.assert_called_once_with(mock_args)
+        reset_database_password.run.assert_called_once_with(mock_args)
+        reset_redis_password.run.assert_called_once_with(mock_args)
 
 
 def test_systemctl_reload(mock_shell_utils):

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -115,7 +115,7 @@ def test_systemctl_reload(mock_shell_utils):
     install.systemctl_reload()
     mock_shell_utils.run_command.assert_has_calls(
         (
-            mock.call(install.SYSTEMCTL_USER_RESET_FAILED_CMD),
-            mock.call(install.SYSTEMCTL_USER_DAEMON_RELOAD_CMD),
+            mock.call(install.SYSTEMCTL_USER_RESET_FAILED_CMD, quiet=True),
+            mock.call(install.SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True),
         )
     )

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -77,11 +77,13 @@ def test_install_run(
             install, "reset_encryption_secret"
         ) as reset_encryption_secret,
         mock.patch.object(install, "reset_admin_password") as reset_admin_password,
+        mock.patch.object(install, "reset_redis_password") as reset_redis_password,
         mock.patch.object(install, "systemctl_reload") as systemctl_reload,
     ):
         reset_session_secret.session_secret_is_set.return_value = False
         reset_encryption_secret.encryption_secret_is_set.return_value = False
         reset_admin_password.admin_password_is_set.return_value = False
+        reset_redis_password.admin_password_is_set.return_value = False
 
         install.run(mock_args)
 

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -72,18 +72,22 @@ def test_install_run(
     env_dir = temp_config_directories["SERVER_ENV_DIR"]
     systemd_dir = temp_config_directories["SYSTEMD_UNITS_DIR"]
     with (
-        mock.patch.object(install, "reset_session_secret") as reset_session_secret,
         mock.patch.object(
             install, "reset_encryption_secret"
         ) as reset_encryption_secret,
+        mock.patch.object(install, "reset_session_secret") as reset_session_secret,
         mock.patch.object(install, "reset_admin_password") as reset_admin_password,
+        mock.patch.object(
+            install, "reset_database_password"
+        ) as reset_database_password,
         mock.patch.object(install, "reset_redis_password") as reset_redis_password,
         mock.patch.object(install, "systemctl_reload") as systemctl_reload,
     ):
-        reset_session_secret.session_secret_is_set.return_value = False
-        reset_encryption_secret.encryption_secret_is_set.return_value = False
-        reset_admin_password.admin_password_is_set.return_value = False
-        reset_redis_password.admin_password_is_set.return_value = False
+        reset_encryption_secret.is_set.return_value = False
+        reset_session_secret.is_set.return_value = False
+        reset_admin_password.is_set.return_value = False
+        reset_database_password.is_set.return_value = False
+        reset_redis_password.is_set.return_value = False
 
         install.run(mock_args)
 
@@ -106,10 +110,12 @@ def test_install_run(
         parser.read(str((systemd_dir / "quipucords-app.container")))
         assert parser[unit_override_section][unit_override_key] == unit_override_value
 
-        systemctl_reload.assert_called_once()
-        reset_session_secret.run.assert_called_once()
         reset_encryption_secret.run.assert_called_once()
+        reset_session_secret.run.assert_called_once()
         reset_admin_password.run.assert_called_once()
+        reset_database_password.run.assert_called_once()
+        reset_redis_password.run.assert_called_once()
+        systemctl_reload.assert_called_once()
 
 
 def test_systemctl_reload(mock_shell_utils):

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -73,6 +73,7 @@ def test_install_run(
     env_dir = temp_config_directories["SERVER_ENV_DIR"]
     systemd_dir = temp_config_directories["SYSTEMD_UNITS_DIR"]
     with (
+        mock.patch.object(install, "podman_utils") as podman_utils,
         mock.patch.object(install, "reset_secrets") as reset_secrets,
         mock.patch.object(install, "systemctl_reload") as systemctl_reload,
     ):
@@ -80,6 +81,8 @@ def test_install_run(
 
         install.run(mock_args)
 
+        podman_utils.ensure_podman_socket.assert_called_once()
+        podman_utils.ensure_cgroups_v2.assert_called_once()
         reset_secrets.assert_called_once_with(mock_args)
         systemctl_reload.assert_called_once()
 

--- a/tests/commands/test_reset_admin_password.py
+++ b/tests/commands/test_reset_admin_password.py
@@ -16,9 +16,15 @@ class MysteryError(Exception):
         return self.__doc__
 
 
-def test_admin_password_is_set():
-    """Test placeholder for admin_password_is_set."""
-    assert not reset_admin_password.admin_password_is_set()
+@mock.patch.object(reset_admin_password.podman_utils, "secret_exists")
+def test_admin_password_is_set(mock_secret_exists):
+    """Test admin_password_is_set just wraps secret_exists."""
+    assert (
+        reset_admin_password.admin_password_is_set() == mock_secret_exists.return_value
+    )
+    mock_secret_exists.assert_called_once_with(
+        reset_admin_password.ADMIN_PASSWORD_PODMAN_SECRET_NAME
+    )
 
 
 @mock.patch.object(reset_admin_password.podman_utils, "set_secret")

--- a/tests/commands/test_reset_admin_password.py
+++ b/tests/commands/test_reset_admin_password.py
@@ -19,9 +19,7 @@ class MysteryError(Exception):
 @mock.patch.object(reset_admin_password.podman_utils, "secret_exists")
 def test_admin_password_is_set(mock_secret_exists):
     """Test admin_password_is_set just wraps secret_exists."""
-    assert (
-        reset_admin_password.admin_password_is_set() == mock_secret_exists.return_value
-    )
+    assert reset_admin_password.is_set() == mock_secret_exists.return_value
     mock_secret_exists.assert_called_once_with(
         reset_admin_password.ADMIN_PASSWORD_PODMAN_SECRET_NAME
     )

--- a/tests/commands/test_reset_database_password.py
+++ b/tests/commands/test_reset_database_password.py
@@ -1,0 +1,155 @@
+"""Test the "reset_database_password" command."""
+
+import logging
+from unittest import mock
+
+from quipucordsctl.commands import reset_database_password
+
+
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+def test_database_password_is_set(mock_secret_exists):
+    """Test database_password_is_set just wraps secret_exists."""
+    assert (
+        reset_database_password.database_password_is_set()
+        == mock_secret_exists.return_value
+    )
+    mock_secret_exists.assert_called_once_with(
+        reset_database_password.DATABASE_PASSWORD_PODMAN_SECRET_NAME
+    )
+
+
+@mock.patch.object(reset_database_password.podman_utils, "set_secret")
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+@mock.patch.object(reset_database_password.shell_utils, "confirm")
+@mock.patch.object(reset_database_password.secrets, "generate_random_secret")
+@mock.patch.object(reset_database_password.secrets, "prompt_secret")
+def test_reset_database_password_run_fails_set_secret(  # noqa: PLR0913
+    mock_prompt_secret,
+    mock_generate_random_secret,
+    mock_confirm,
+    mock_secret_exists,
+    mock_set_secret,
+    good_secret,
+    caplog,
+):
+    """Test reset_database_password.run when set_secret fails unexpectedly."""
+    caplog.set_level(logging.ERROR)
+    mock_args = mock.Mock()
+    mock_args.prompt = False
+    mock_secret_exists.return_value = False  # act like first-time setup
+    mock_generate_random_secret.return_value = good_secret
+    mock_set_secret.return_value = False  # might happen in a race condition
+
+    assert not reset_database_password.run(mock_args)
+    mock_secret_exists.assert_called_once()
+    mock_set_secret.assert_called_once()
+    mock_prompt_secret.assert_not_called()  # no prompts for default first-time setup
+    mock_confirm.assert_not_called()  # no prompts for default first-time setup
+    assert "The database password was not updated." == caplog.messages[0]
+
+
+@mock.patch.object(reset_database_password.podman_utils, "set_secret")
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+@mock.patch.object(reset_database_password.shell_utils, "confirm")
+@mock.patch.object(reset_database_password.secrets, "generate_random_secret")
+@mock.patch.object(reset_database_password.secrets, "prompt_secret")
+def test_reset_database_password_run_success(  # noqa: PLR0913
+    mock_prompt_secret,
+    mock_generate_random_secret,
+    mock_confirm,
+    mock_secret_exists,
+    mock_set_secret,
+    good_secret,
+):
+    """Test reset_database_password.run is successful with default (no prompt) args."""
+    mock_args = mock.Mock()
+    mock_args.prompt = False
+    mock_secret_exists.return_value = False  # act like first-time setup
+    mock_generate_random_secret.return_value = good_secret
+    mock_set_secret.return_value = True
+
+    assert reset_database_password.run(mock_args)
+    mock_secret_exists.assert_called_once_with(
+        reset_database_password.DATABASE_PASSWORD_PODMAN_SECRET_NAME
+    )
+    mock_set_secret.assert_called_once_with(
+        reset_database_password.DATABASE_PASSWORD_PODMAN_SECRET_NAME,
+        good_secret,
+        False,
+    )
+    mock_prompt_secret.assert_not_called()  # no prompts for default first-time setup
+    mock_confirm.assert_not_called()  # no prompts for default first-time setup
+
+
+@mock.patch.object(reset_database_password.podman_utils, "set_secret")
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+@mock.patch.object(reset_database_password.shell_utils, "confirm")
+@mock.patch.object(reset_database_password.secrets, "prompt_secret")
+def test_reset_database_password_run_with_prompts_success(  # noqa: PLR0913
+    mock_prompt_password,
+    mock_confirm,
+    mock_secret_exists,
+    mock_set_secret,
+    good_secret,
+):
+    """Test reset_database_password.run is successful with user input prompts."""
+    mock_args = mock.Mock()
+    mock_args.prompt = True  # require user to confirm
+    mock_confirm.return_value = True  # act like use always enters 'y'
+    mock_secret_exists.return_value = True
+    mock_set_secret.return_value = True
+    mock_prompt_password.return_value = good_secret
+
+    assert reset_database_password.run(mock_args)
+    mock_secret_exists.assert_called_once()
+    mock_prompt_password.assert_called_once()
+    mock_set_secret.assert_called_once_with(
+        reset_database_password.DATABASE_PASSWORD_PODMAN_SECRET_NAME,
+        good_secret,
+        True,
+    )
+    assert len(mock_confirm.call_args_list) == 2
+
+
+@mock.patch.object(reset_database_password.podman_utils, "set_secret")
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+@mock.patch.object(reset_database_password.shell_utils, "confirm")
+@mock.patch.object(reset_database_password.secrets, "prompt_secret")
+def test_reset_database_password_run_decline_replace_existing(  # noqa: PLR0913
+    mock_prompt_password,
+    mock_confirm,
+    mock_secret_exists,
+    mock_set_secret,
+):
+    """Test reset_database_password.run if user declines to replace existing secret."""
+    mock_args = mock.Mock()
+    mock_args.prompt = True  # require user to confirm
+    mock_confirm.return_value = False  # act like use always enters 'n'
+
+    assert not reset_database_password.run(mock_args)
+    mock_secret_exists.assert_called_once()
+    mock_prompt_password.assert_not_called()
+    mock_set_secret.assert_not_called()
+    assert len(mock_confirm.call_args_list) == 1
+
+
+@mock.patch.object(reset_database_password.podman_utils, "set_secret")
+@mock.patch.object(reset_database_password.podman_utils, "secret_exists")
+@mock.patch.object(reset_database_password.shell_utils, "confirm")
+@mock.patch.object(reset_database_password.secrets, "prompt_secret")
+def test_reset_database_password_run_decline_manual_input(  # noqa: PLR0913
+    mock_prompt_password,
+    mock_confirm,
+    mock_secret_exists,
+    mock_set_secret,
+):
+    """Test reset_database_password.run if user declines manual input confirmation."""
+    mock_args = mock.Mock()
+    mock_args.prompt = True  # require user to confirm
+    mock_confirm.side_effect = [True, False]  # act like use enters 'y' then 'n'
+
+    assert not reset_database_password.run(mock_args)
+    mock_secret_exists.assert_called_once()
+    mock_prompt_password.assert_not_called()
+    mock_set_secret.assert_not_called()
+    assert len(mock_confirm.call_args_list) == 2

--- a/tests/commands/test_reset_database_password.py
+++ b/tests/commands/test_reset_database_password.py
@@ -9,10 +9,7 @@ from quipucordsctl.commands import reset_database_password
 @mock.patch.object(reset_database_password.podman_utils, "secret_exists")
 def test_database_password_is_set(mock_secret_exists):
     """Test database_password_is_set just wraps secret_exists."""
-    assert (
-        reset_database_password.database_password_is_set()
-        == mock_secret_exists.return_value
-    )
+    assert reset_database_password.is_set() == mock_secret_exists.return_value
     mock_secret_exists.assert_called_once_with(
         reset_database_password.DATABASE_PASSWORD_PODMAN_SECRET_NAME
     )

--- a/tests/commands/test_reset_encryption_secret.py
+++ b/tests/commands/test_reset_encryption_secret.py
@@ -9,10 +9,7 @@ from quipucordsctl.commands import reset_encryption_secret
 @mock.patch.object(reset_encryption_secret.podman_utils, "secret_exists")
 def test_encryption_secret_is_set(mock_secret_exists):
     """Test encryption_secret_is_set just wraps secret_exists."""
-    assert (
-        reset_encryption_secret.encryption_secret_is_set()
-        == mock_secret_exists.return_value
-    )
+    assert reset_encryption_secret.is_set() == mock_secret_exists.return_value
     mock_secret_exists.assert_called_once_with(
         reset_encryption_secret.ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME
     )

--- a/tests/commands/test_reset_encryption_secret.py
+++ b/tests/commands/test_reset_encryption_secret.py
@@ -6,9 +6,16 @@ from unittest import mock
 from quipucordsctl.commands import reset_encryption_secret
 
 
-def test_encryption_secret_is_set():
-    """Test placeholder for encryption_secret_is_set."""
-    assert not reset_encryption_secret.encryption_secret_is_set()
+@mock.patch.object(reset_encryption_secret.podman_utils, "secret_exists")
+def test_encryption_secret_is_set(mock_secret_exists):
+    """Test encryption_secret_is_set just wraps secret_exists."""
+    assert (
+        reset_encryption_secret.encryption_secret_is_set()
+        == mock_secret_exists.return_value
+    )
+    mock_secret_exists.assert_called_once_with(
+        reset_encryption_secret.ENCRYPTION_SECRET_KEY_PODMAN_SECRET_NAME
+    )
 
 
 @mock.patch.object(reset_encryption_secret.podman_utils, "set_secret")

--- a/tests/commands/test_reset_redis_password.py
+++ b/tests/commands/test_reset_redis_password.py
@@ -9,9 +9,7 @@ from quipucordsctl.commands import reset_redis_password
 @mock.patch.object(reset_redis_password.podman_utils, "secret_exists")
 def test_redis_password_is_set(mock_secret_exists):
     """Test redis_password_is_set just wraps secret_exists."""
-    assert (
-        reset_redis_password.redis_password_is_set() == mock_secret_exists.return_value
-    )
+    assert reset_redis_password.is_set() == mock_secret_exists.return_value
     mock_secret_exists.assert_called_once_with(
         reset_redis_password.REDIS_PASSWORD_PODMAN_SECRET_NAME
     )

--- a/tests/commands/test_reset_redis_password.py
+++ b/tests/commands/test_reset_redis_password.py
@@ -1,0 +1,111 @@
+"""Test the "reset_redis_password" command."""
+
+import logging
+from unittest import mock
+
+from quipucordsctl.commands import reset_redis_password
+
+
+@mock.patch.object(reset_redis_password.podman_utils, "secret_exists")
+def test_redis_password_is_set(mock_secret_exists):
+    """Test redis_password_is_set just wraps secret_exists."""
+    assert (
+        reset_redis_password.redis_password_is_set() == mock_secret_exists.return_value
+    )
+    mock_secret_exists.assert_called_once_with(
+        reset_redis_password.REDIS_PASSWORD_PODMAN_SECRET_NAME
+    )
+
+
+@mock.patch.object(reset_redis_password.podman_utils, "set_secret")
+@mock.patch.object(reset_redis_password.shell_utils, "confirm")
+@mock.patch.object(reset_redis_password.secrets, "generate_random_secret")
+@mock.patch.object(reset_redis_password.secrets, "prompt_secret")
+def test_reset_redis_password_run_success(  # noqa: PLR0913
+    mock_prompt_secret,
+    mock_generate_random_secret,
+    mock_confirm,
+    mock_set_secret,
+    good_secret,
+):
+    """Test reset_redis_password.run is successful with default (no prompt) args."""
+    mock_args = mock.Mock()
+    mock_args.prompt = False
+    mock_generate_random_secret.return_value = good_secret
+    mock_set_secret.return_value = True
+
+    assert reset_redis_password.run(mock_args)
+    mock_set_secret.assert_called_once_with(
+        reset_redis_password.REDIS_PASSWORD_PODMAN_SECRET_NAME, good_secret
+    )
+    mock_prompt_secret.assert_not_called()  # no prompts for default first-time setup
+    mock_confirm.assert_not_called()  # no prompts for default first-time setup
+
+
+@mock.patch.object(reset_redis_password.podman_utils, "set_secret")
+@mock.patch.object(reset_redis_password.shell_utils, "confirm")
+@mock.patch.object(reset_redis_password.secrets, "prompt_secret")
+def test_reset_redis_password_run_with_prompts_success(  # noqa: PLR0913
+    mock_prompt_password,
+    mock_confirm,
+    mock_set_secret,
+    good_secret,
+):
+    """Test reset_redis_password.run is successful with user input prompts."""
+    mock_args = mock.Mock()
+    mock_args.prompt = True  # require user to confirm
+    mock_confirm.return_value = True  # act like use enters 'y'
+    mock_set_secret.return_value = True
+    mock_prompt_password.return_value = good_secret
+
+    assert reset_redis_password.run(mock_args)
+    mock_prompt_password.assert_called_once()
+    mock_set_secret.assert_called_once_with(
+        reset_redis_password.REDIS_PASSWORD_PODMAN_SECRET_NAME, good_secret
+    )
+    assert len(mock_confirm.call_args_list) == 1
+
+
+@mock.patch.object(reset_redis_password.podman_utils, "set_secret")
+@mock.patch.object(reset_redis_password.shell_utils, "confirm")
+@mock.patch.object(reset_redis_password.secrets, "prompt_secret")
+def test_reset_redis_password_run_decline_manual_input(  # noqa: PLR0913
+    mock_prompt_password,
+    mock_confirm,
+    mock_set_secret,
+):
+    """Test reset_redis_password.run if user declines manual input confirmation."""
+    mock_args = mock.Mock()
+    mock_args.prompt = True  # require user to confirm
+    mock_confirm.return_value = False  # act like use enters 'n'
+
+    assert not reset_redis_password.run(mock_args)
+    mock_prompt_password.assert_not_called()
+    mock_set_secret.assert_not_called()
+    assert len(mock_confirm.call_args_list) == 1
+
+
+@mock.patch.object(reset_redis_password.podman_utils, "set_secret")
+@mock.patch.object(reset_redis_password.shell_utils, "confirm")
+@mock.patch.object(reset_redis_password.secrets, "generate_random_secret")
+@mock.patch.object(reset_redis_password.secrets, "prompt_secret")
+def test_reset_redis_password_run_fails_set_secret(  # noqa: PLR0913
+    mock_prompt_secret,
+    mock_generate_random_secret,
+    mock_confirm,
+    mock_set_secret,
+    good_secret,
+    caplog,
+):
+    """Test reset_redis_password.run when set_secret fails unexpectedly."""
+    caplog.set_level(logging.ERROR)
+    mock_args = mock.Mock()
+    mock_args.prompt = False
+    mock_generate_random_secret.return_value = good_secret
+    mock_set_secret.return_value = False  # might happen in a race condition
+
+    assert not reset_redis_password.run(mock_args)
+    mock_set_secret.assert_called_once()
+    mock_prompt_secret.assert_not_called()  # no prompts for default first-time setup
+    mock_confirm.assert_not_called()  # no prompts for default first-time setup
+    assert "The Redis password was not updated." == caplog.messages[0]

--- a/tests/commands/test_reset_session_secret.py
+++ b/tests/commands/test_reset_session_secret.py
@@ -9,9 +9,7 @@ from quipucordsctl.commands import reset_session_secret
 @mock.patch.object(reset_session_secret.podman_utils, "secret_exists")
 def test_session_secret_is_set(mock_secret_exists):
     """Test session_secret_is_set just wraps secret_exists."""
-    assert (
-        reset_session_secret.session_secret_is_set() == mock_secret_exists.return_value
-    )
+    assert reset_session_secret.is_set() == mock_secret_exists.return_value
     mock_secret_exists.assert_called_once_with(
         reset_session_secret.SESSION_SECRET_PODMAN_SECRET_NAME
     )

--- a/tests/commands/test_reset_session_secret.py
+++ b/tests/commands/test_reset_session_secret.py
@@ -6,9 +6,15 @@ from unittest import mock
 from quipucordsctl.commands import reset_session_secret
 
 
-def test_application_secret_is_set():
-    """Test placeholder for application_secret_is_set."""
-    assert not reset_session_secret.session_secret_is_set()
+@mock.patch.object(reset_session_secret.podman_utils, "secret_exists")
+def test_session_secret_is_set(mock_secret_exists):
+    """Test session_secret_is_set just wraps secret_exists."""
+    assert (
+        reset_session_secret.session_secret_is_set() == mock_secret_exists.return_value
+    )
+    mock_secret_exists.assert_called_once_with(
+        reset_session_secret.SESSION_SECRET_PODMAN_SECRET_NAME
+    )
 
 
 @mock.patch.object(reset_session_secret.podman_utils, "set_secret")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,7 +137,7 @@ def test_cli_without_command():
     with mock.patch.object(cli, "create_parser") as mock_create_parser:
         mock_parser = mock_create_parser.return_value
         mock_args = mock_parser.parse_args.return_value
-        mock_args.verbosity = 0
+        mock_args.verbosity = 0  # need any int because MagicMock is not int-like
         mock_args.quiet = True
         mock_args.command = None
 
@@ -158,6 +158,7 @@ def test_cli_nonzero_exit_when_command_fails():
         mock_parser = mock_create_parser.return_value
         mock_args = mock_parser.parse_args.return_value
         mock_args.command = command_name
+        mock_args.verbosity = 0  # need any int because MagicMock is not int-like
 
         mock_command = MagicMock()
         mock_command.run.return_value = False
@@ -190,6 +191,7 @@ def test_cli_nonzero_exit_when_command_raises_exception(
         mock_parser = mock_create_parser.return_value
         mock_args = mock_parser.parse_args.return_value
         mock_args.command = command_name
+        mock_args.verbosity = 0  # need any int because MagicMock is not int-like
 
         mock_command = MagicMock()
         mock_command.run.side_effect = exception

--- a/tests/test_systemdunitparser.py
+++ b/tests/test_systemdunitparser.py
@@ -1,0 +1,35 @@
+"""Basic tests for SystemdUnitParser."""
+
+import pytest
+
+from quipucordsctl.systemdunitparser import SystemdUnitParser
+
+EXAMPLE_CONFIG = """
+[hello]
+foo=bar
+biz=hello
+biz=world
+port=99999
+
+[other]
+"""
+
+
+@pytest.fixture
+def example_config(tmpdir):
+    """Create example config files as a test fixture."""
+    file_path = tmpdir.join("example.service")
+    with file_path.open("w") as fp:
+        fp.write(EXAMPLE_CONFIG)
+    yield file_path
+
+
+def test_read(example_config):
+    """Test reading a systemd-style config file."""
+    parser = SystemdUnitParser()
+    parser.read(str(example_config))
+    assert parser.sections() == ["hello", "other"]
+    assert parser["hello"]["foo"] == "bar"
+    assert parser["hello"]["biz"] == ("hello", "world")
+    assert parser["hello"]["port"] == "99999"  # always strings
+    assert parser["other"] == {}


### PR DESCRIPTION
This is a big one. In hindsight, this should have been multiple PRs, but I was in too deep before I realized that. Specifically, I didn't realize we didn't have `reset_database_password` or `reset_redis_password` commands yet defined in `quipucordctl`, and the `install` command needs them to work completely. Those commands did not yet exist in `quipucords-installer` either when I first started writing code for `quipucordsctl`. Whoops!

The main feature of this PR is the addition of the `install` command. That command relies on (and invokes functions from) several other commands. `quipucordsctl install` is intended to be the single command a user needs to invoke to set up their system with the appropriate config files for running `quipucords`.

This PR includes code from https://github.com/sgallagher/systemdunitparser in `./src/quipucordsctl/systemdunitparser/__init__.py`. I checked with `opensource-legal@redhat.com`, and my contact reassured me that we may "vendor" it and include this code as license-compatible with `quipucords`. I am doing this because packages for `systemdunitparser` are not available where we would need users to install our product, but `systemdunitparser` provides much-needed help reading and writing systemd-style files. I included the original code from `systemdunitparser` in a single commit with a message describing its origins, and I made minor edits to make `ruff` happy in subsequent commits, at which time I added a brief message to the top of the file to explain the changes I made. That should satisfy the needs of the license.

As of this change, the `install` command should provide parity functionality with `quipucords-installer install`. That is to say _this_ version of the `install` command still _does not_ pull the images and still does not start the service for you, which are features I _wanted_, but those additional behaviors have been relegated to a future iteration of this code. However, this code _should_ be much more explicit about handling errors and logging useful progress along the way, and of course we have unit test coverage here.

`quipucordsctl` supports variable verbosity with multiple `-v` flags, and the logic I'm introducing here takes full advantage of that to emit information at different log levels where I felt appropriate. As a reminder, `-v` enables `info` messages, `-vv` enables `debug` messages, and `-vvv` adds timestamps to messages. Example outputs with different verbosity levels:

```
quipucordsctl -c ~/.config/qpcoverrides install

Installation completed successfully. Please run the following commands to start the Quipucords server:

    podman login registry.redhat.io
    systemctl --user restart quipucords-app
```

```
quipucordsctl -v -c ~/.config/qpcoverrides install
INFO: Generating config files
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords.network
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-app.container
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-celery-worker.container
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-db.container
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-redis.container
INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-server.container
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-ansible.env
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-app.env
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-celery-worker.env
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-db.env
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-redis.env
INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-server.env
INFO: Reloading systemctl to recognize Quipucords units

Installation completed successfully. Please run the following commands to start the Quipucords server:

    podman login registry.redhat.io
    systemctl --user restart quipucords-app
```

```
quipucordsctl -vvv -c ~/.config/qpcoverrides install
2025-09-15 19:18:27 DEBUG: Starting install command
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Starting new HTTP connection (1): %2fvar%2frun%2fdocker.sock:80
2025-09-15 19:18:27 DEBUG: http://%2fvar%2frun%2fdocker.sock:80 "GET /v4.9.0/libpod/secrets/quipucords-django-secret-key/json HTTP/1.1" 200 306
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Starting new HTTP connection (1): %2fvar%2frun%2fdocker.sock:80
2025-09-15 19:18:27 DEBUG: http://%2fvar%2frun%2fdocker.sock:80 "GET /v4.9.0/libpod/secrets/quipucords-session-secret-key/json HTTP/1.1" 200 307
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Starting new HTTP connection (1): %2fvar%2frun%2fdocker.sock:80
2025-09-15 19:18:27 DEBUG: http://%2fvar%2frun%2fdocker.sock:80 "GET /v4.9.0/libpod/secrets/quipucords-server-password/json HTTP/1.1" 200 304
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Starting new HTTP connection (1): %2fvar%2frun%2fdocker.sock:80
2025-09-15 19:18:27 DEBUG: http://%2fvar%2frun%2fdocker.sock:80 "GET /v4.9.0/libpod/secrets/quipucords-db-password/json HTTP/1.1" 200 300
2025-09-15 19:18:27 DEBUG: Ensuring Podman socket is available.
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['podman', 'machine', 'inspect', '--format', '{{.State}}']
2025-09-15 19:18:27 DEBUG: Starting new HTTP connection (1): %2fvar%2frun%2fdocker.sock:80
2025-09-15 19:18:27 DEBUG: http://%2fvar%2frun%2fdocker.sock:80 "GET /v4.9.0/libpod/secrets/quipucords-redis-password/json HTTP/1.1" 200 303
2025-09-15 19:18:27 INFO: Generating config files
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.config/quipucords/env
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.config/containers/systemd
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.local/share/quipucords/certs
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.local/share/quipucords/data
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.local/share/quipucords/db
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.local/share/quipucords/log
2025-09-15 19:18:27 DEBUG: Ensuring directory exists: /Users/brasmith/.local/share/quipucords/sshkeys
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/quipucords.network
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords.network
2025-09-15 19:18:27 DEBUG: Override file found at: /Users/brasmith/.config/qpcoverrides/quipucords-app.container
2025-09-15 19:18:27 DEBUG: Overriding quipucords-app.container Unit.Description from Quipucords App to Potato App
2025-09-15 19:18:27 DEBUG: Overriding quipucords-app.container Unit.Wants from None to ('papas', 'fritas')
2025-09-15 19:18:27 DEBUG: Overriding quipucords-app.container Container.ContainerName from quipucords-app to potato-app
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-app.container
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/quipucords-celery-worker.container
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-celery-worker.container
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/quipucords-db.container
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-db.container
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/quipucords-redis.container
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-redis.container
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/quipucords-server.container
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/containers/systemd/quipucords-server.container
2025-09-15 19:18:27 DEBUG: Override file found at: /Users/brasmith/.config/qpcoverrides/env-ansible.env
2025-09-15 19:18:27 DEBUG: Override file for env-ansible.env appears to be empty and will be skipped.
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-ansible.env
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/env-app.env
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-app.env
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/env-celery-worker.env
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-celery-worker.env
2025-09-15 19:18:27 DEBUG: No override file found at: /Users/brasmith/.config/qpcoverrides/env-db.env
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-db.env
2025-09-15 19:18:27 DEBUG: Override file found at: /Users/brasmith/.config/qpcoverrides/env-redis.env
2025-09-15 19:18:27 DEBUG: Override file for env-redis.env appears to be empty and will be skipped.
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-redis.env
2025-09-15 19:18:27 DEBUG: Override file found at: /Users/brasmith/.config/qpcoverrides/env-server.env
2025-09-15 19:18:27 DEBUG: Appending overrides (2 lines) to template for env-server.env before writing.
2025-09-15 19:18:27 INFO: Writing config to /Users/brasmith/.config/quipucords/env/env-server.env
2025-09-15 19:18:27 INFO: Reloading systemctl to recognize Quipucords units
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['systemctl', '--user', 'reset-failed']
2025-09-15 19:18:27 DEBUG: Invoking subprocess with arguments ['systemctl', '--user', 'daemon-reload']

Installation completed successfully. Please run the following commands to start the Quipucords server:

    podman login registry.redhat.io
    systemctl --user restart quipucords-app
```

Relates to JIRA: DISCOVERY-962

## Summary by Sourcery

Add new install command that resets secrets, generates and writes config files (with support for user overrides), checks Podman readiness, and reloads systemd units. Introduce dedicated reset_database_password and reset_redis_password commands. Vendor SystemdUnitParser for merging systemd unit templates and enhance logging, error handling, and test coverage across commands.

New Features:
- Introduce install command orchestrating secret resets, config generation, and systemd reload
- Add reset_database_password command for managing database passwords via Podman secrets
- Add reset_redis_password command for managing Redis passwords via Podman secrets

Enhancements:
- Vendor SystemdUnitParser to support parsing and merging systemd-style unit files
- Extend shell_utils.run_command with quiet flag, detailed logging, and error handling
- Implement podman_utils.ensure_podman_socket to verify Podman socket availability before operations
- Enhance logging format in CLI to respect verbosity levels and handle Podman readiness errors
- Refactor settings to explicitly list systemd and env template filenames

Documentation:
- Update README with instructions for running quipucordsctl directly and installed from source

Tests:
- Add tests for reset_database_password and reset_redis_password commands
- Expand install command tests to cover override merging for systemd units and env files
- Add tests for reset_secrets helper, mkdirs behavior, and SystemdUnitParser functionality
- Update existing secret-reset command tests to assert correct Podman secret existence logic