### PR TITLE
Draft: Compile message catalogs with pybabel

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,39 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: quipucordsctl.spec
+
+upstream_project_url: https://github.com/quipucords/quipucordsctl
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets: &targets_list
+      # we officially support rhel-8 and rhel-9 downstream.
+      - rhel-8-x86_64
+      - rhel-8-aarch64
+      - rhel-9-x86_64
+      - rhel-9-aarch64
+      - rhel-10-x86_64
+      - rhel-10-aarch64
+      # centos-stream is like a preview of upcoming rhel.
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      # fedora is like an even farther future preview.
+      - fedora-43-x86_64
+      - fedora-43-aarch64
+
+  - job: copr_build
+    trigger: commit
+    branch: "^main$"
+    owner: "@quipucords"
+    project: "quipucordsctl-latest"
+    preserve_project: True
+    targets: *targets_list
+
+  - job: copr_build
+    trigger: release
+    owner: "@quipucords"
+    project: "quipucordsctl"
+    preserve_project: True
+    targets: *targets_list

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,22 +10,18 @@ jobs:
     trigger: pull_request
     targets: &targets_list
       # we officially support RHEL 8 and RHEL 9 downstream.
-      ## - rhel-8-x86_64    (no pyproject-rpm-macro RPM !!)
-      ## - rhel-8-aarch64
+      - rhel-8-x86_64
+      - rhel-8-aarch64
       - rhel-9-x86_64
       - rhel-9-aarch64
       # we also build for RHEL 10
       - rhel-10-x86_64
       - rhel-10-aarch64
-      # we also build on Fedora as an early preview of future releases.
-      # Fedora 41 and 42 on Python 3.13
-      # Fedora 43 on Python 3.14  (quipucords supports up through 3.13)
+      # and also build on Fedora as an early preview of future releases.
       - fedora-41-x86_64
       - fedora-41-aarch64
       - fedora-42-x86_64
       - fedora-42-aarch64
-      ## - fedora-43-x86_64
-      ## - fedora-43-aarch64
 
   - job: copr_build
     trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,19 +9,23 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets: &targets_list
-      # we officially support rhel-8 and rhel-9 downstream.
-      - rhel-8-x86_64
-      - rhel-8-aarch64
+      # we officially support RHEL 8 and RHEL 9 downstream.
+      ## - rhel-8-x86_64    (no pyproject-rpm-macro RPM !!)
+      ## - rhel-8-aarch64
       - rhel-9-x86_64
       - rhel-9-aarch64
+      # we also build for RHEL 10
       - rhel-10-x86_64
       - rhel-10-aarch64
-      # centos-stream is like a preview of upcoming rhel.
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-      # fedora is like an even farther future preview.
-      - fedora-43-x86_64
-      - fedora-43-aarch64
+      # we also build on Fedora as an early preview of future releases.
+      # Fedora 41 and 42 on Python 3.13
+      # Fedora 43 on Python 3.14  (quipucords supports up through 3.13)
+      - fedora-41-x86_64
+      - fedora-41-aarch64
+      - fedora-42-x86_64
+      - fedora-42-aarch64
+      ## - fedora-43-x86_64
+      ## - fedora-43-aarch64
 
   - job: copr_build
     trigger: commit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
+# Installing Quipucords using `quipucordsctl`
+
+## What is this?
+
+`quipucordsctl` is a management tool that you can use to install and configure Quipucords and all of its required components to run in Podman containers on your local system.
+
+## Using the RPM
+
+> [!IMPORTANT]
+> Installing the `quipucordsctl` RPM itself requires `sudo` or elevated `root` privileges, but ***all other commands*** for installing and interacting with Quipucords through the `quipucordsctl` program should be executed as a *regular non-root* user. If you install and run Quipucords as `root`, expect no support from the maintainers.
+
+To prepare `quipucordsctl`:
+
+```sh
+sudo dnf copr enable -y @quipucords/quipucordsctl
+sudo dnf install -y quipucordsctl
+```
+
+
+To install, configure, and start Quipucords:
+
+```sh
+quipucordsctl install
+podman login registry.redhat.io  # REQUIRED before starting quipucords-app
+systemctl --user start quipucords-app
+```
+
+A few seconds later, you may access Quipucords on https://localhost:9443
+
+If you want to access Quipucords from systems outside of localhost, you may need to add a rule to allow access through the firewall:
+
+```sh
+sudo firewall-cmd --permanent --add-port=9443/tcp  # optional if you want external access
+sudo firewall-cmd --reload  # optional if you want external access
+```
+
 # quipucordsctl
 
 ## setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ authors = [
 license = {text = "GPL-3.0-or-later"}
 readme = "README.md"
 dependencies = [
-    "podman==4.9.0",
+    "podman>=4.9.0",
 ]
 
 [dependency-groups]

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -30,6 +30,7 @@ BuildRequires:  sed
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-babel
 
 Requires:       bash
 Requires:       coreutils
@@ -53,6 +54,14 @@ sed -i \
   %{_builddir}/quipucordsctl-%{version}/pyproject.toml
 python%{python3_pkgversion} -m ensurepip
 python%{python3_pkgversion} -m pip install wheel
+
+# Let's compile the message catalogs
+python%{python3_pkgversion} -m venv translations-env
+source translations-env/bin/activate
+python%{python3_pkgversion} -m pip install babel
+python%{python3_pkgversion} scripts/translations.py compile
+rm -rf translations-env
+
 %pyproject_wheel
 
 %install

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -5,12 +5,17 @@
 %global ui_image quay.io/quipucords/quipucords-ui:2.1
 %global templates_dir src/quipucordsctl/templates
 
-%if 0%{?fedora} >= 41
-    %global python3_pkgversion  3.13
-    %global __python3 /usr/bin/python3.13
+%if 0%{?fedora} >= 43
+    %global python3_pkgversion  3.14
+    %global __python3 /usr/bin/python3.14
 %else
-    %global python3_pkgversion  3.12
-    %global __python3 /usr/bin/python3.12
+    %if 0%{?fedora} >= 41
+        %global python3_pkgversion  3.13
+        %global __python3 /usr/bin/python3.13
+    %else
+        %global python3_pkgversion  3.12
+        %global __python3 /usr/bin/python3.12
+    %endif
 %endif
 
 
@@ -29,8 +34,10 @@ BuildArch:      noarch
 BuildRequires:  sed
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  python%{python3_pkgversion}-babel
+BuildRequires:  python3-babel
+BuildRequires:  babel
 
 Requires:       bash
 Requires:       coreutils
@@ -53,14 +60,8 @@ sed -i \
   -e 's/^version = "0.1.0"$/version = "%{version}"/' \
   %{_builddir}/quipucordsctl-%{version}/pyproject.toml
 python%{python3_pkgversion} -m ensurepip
-python%{python3_pkgversion} -m pip install wheel
-
-# Let's compile the message catalogs
-python%{python3_pkgversion} -m venv translations-env
-source translations-env/bin/activate
-python%{python3_pkgversion} -m pip install babel
-python%{python3_pkgversion} scripts/translations.py compile
-rm -rf translations-env
+python%{python3_pkgversion} -m pip install wheel setuptools
+python%{python3_pkgversion} scripts/translations.py compile    # Compile the message catalogs
 
 %pyproject_wheel
 

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -48,12 +48,22 @@ Source0:        %{url}/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  sed
+# Note: for RHEL 8, pyproject-rpm-macros is not available
+#       we build using the older py3_build and py3_install.
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 9
 BuildRequires:  pyproject-rpm-macros
 %endif
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  python%{python3_pkgversion}-setuptools
+# Note: default python3-babel /usr/bin/pybabel cannot compile uninstalled
+#       locales, so 'test' could not be compiled.
+%if 0%{?rhel} == 8
+BuildRequires:  python38-babel
+%else
+BuildRequires:  python3-babel
+%endif
+BuildRequires:  babel
 
 Requires:       bash
 Requires:       coreutils
@@ -77,6 +87,12 @@ sed -i \
   %{_builddir}/quipucordsctl-%{version}/pyproject.toml
 python%{python3_pkgversion} -m ensurepip
 python%{python3_pkgversion} -m pip install wheel setuptools
+
+%if 0%{?rhel} == 8
+python3 scripts/translations.py --pybabel /usr/bin/pybabel-3.8 compile
+%else
+python3 scripts/translations.py --pybabel /usr/bin/pybabel compile
+%endif
 
 %if 0%{?rhel} == 8
     %py3_build

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -4,8 +4,14 @@
 %global server_image quay.io/quipucords/quipucords:2.1
 %global ui_image quay.io/quipucords/quipucords-ui:2.1
 %global templates_dir src/quipucordsctl/templates
-%global python3_pkgversion  3.12
-%global __python3 /usr/bin/python3.12
+
+%if 0%{?fedora} >= 41
+    %global python3_pkgversion  3.13
+    %global __python3 /usr/bin/python3.13
+%else
+    %global python3_pkgversion  3.12
+    %global __python3 /usr/bin/python3.12
+%endif
 
 
 Name:           %{product_name_lower}ctl
@@ -21,16 +27,16 @@ Source0:        %{url}/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  sed
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  pyproject-rpm-macros
 
 Requires:       bash
 Requires:       coreutils
 Requires:       podman >= 4.9.4
 Requires:       python3-podman
 Requires:       python%{python3_pkgversion}
-Requires:       python%{python3_pkgversion}-setuptools
+
 
 %description
 %{name} installs and manages the %{product_name_title} server
@@ -38,16 +44,15 @@ via systemd using Podman Quadlet services.
 
 %prep
 # Note: this must match the GitHub repo name. Do not substitute variables.
-%autosetup -p1 -n quipucordsctl-%{version}
+%autosetup -n quipucordsctl-%{version}
 
 %build
 sed -i \
   -e 's/^quipucordsctl = "quipucordsctl.__main__:main"$/%{name} = "quipucordsctl.__main__:main"/' \
   -e 's/^version = "0.1.0"$/version = "%{version}"/' \
   %{_builddir}/quipucordsctl-%{version}/pyproject.toml
-%{python3} -m ensurepip 
-%{python3} -m pip install wheel
-%{python3} -m pip install --prefix=%{buildroot}%{python3_sitelib} .
+python%{python3_pkgversion} -m ensurepip
+python%{python3_pkgversion} -m pip install wheel
 %pyproject_wheel
 
 %install

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -1,0 +1,98 @@
+%global product_name_lower quipucords
+%global product_name_title Quipucords
+%global version_installer 2.1.0
+%global server_image quay.io/quipucords/quipucords:2.1
+%global ui_image quay.io/quipucords/quipucords-ui:2.1
+%global templates_dir src/quipucordsctl/templates
+%global python3_pkgversion  3.12
+%global __python3 /usr/bin/python3.12
+
+
+Name:           %{product_name_lower}ctl
+Summary:        installer for %{product_name_lower} server
+
+Version:        %{version_installer}
+Release:        1%{?dist}
+Epoch:          0
+
+License:        GPLv3
+URL:            https://github.com/quipucords/quipucordsctl
+Source0:        %{url}/archive/%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  sed
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       bash
+Requires:       coreutils
+Requires:       podman >= 4.9.4
+Requires:       python3-podman
+Requires:       python%{python3_pkgversion}
+Requires:       python%{python3_pkgversion}-setuptools
+
+%description
+%{name} installs and manages the %{product_name_title} server
+via systemd using Podman Quadlet services.
+
+%prep
+# Note: this must match the GitHub repo name. Do not substitute variables.
+%autosetup -p1 -n quipucordsctl-%{version}
+
+%build
+sed -i \
+  -e 's/^quipucordsctl = "quipucordsctl.__main__:main"$/%{name} = "quipucordsctl.__main__:main"/' \
+  -e 's/^version = "0.1.0"$/version = "%{version}"/' \
+  %{_builddir}/quipucordsctl-%{version}/pyproject.toml
+%{python3} -m ensurepip 
+%{python3} -m pip install wheel
+%{python3} -m pip install --prefix=%{buildroot}%{python3_sitelib} .
+%pyproject_wheel
+
+%install
+%pyproject_install
+mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_datadir}/%{name}/env
+cp %{templates_dir}/env/*.env %{buildroot}/%{_datadir}/%{name}/env/
+
+# Copy and rename original source files with appropriate branding.
+mkdir -p %{buildroot}/%{_datadir}/%{name}/config
+cp %{templates_dir}/config/quipucords-app.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-app.container
+cp %{templates_dir}/config/quipucords-celery-worker.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-celery-worker.container
+cp %{templates_dir}/config/quipucords-db.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-db.container
+cp %{templates_dir}/config/quipucords-redis.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-redis.container
+cp %{templates_dir}/config/quipucords-server.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-server.container
+cp %{templates_dir}/config/quipucords.network %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}.network
+
+# Update source files contents with appropriate branding.
+sed -i 's/Quipucords/%{product_name_title}/g;s/quipucords/%{product_name_lower}/g' %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}*
+sed -i 's/Quipucords/%{product_name_title}/g;s/quipucords/%{product_name_lower}/g' %{buildroot}/%{_datadir}/%{name}/env/*
+
+# Inject specific image versions into the container files.
+sed -i 's#^Image=.*#Image=%{server_image}#g' %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-server.container
+sed -i 's#^Image=.*#Image=%{server_image}#g' %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-celery-worker.container
+sed -i 's#^Image=.*#Image=%{ui_image}#g' %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-app.container
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+%{_datadir}/%{name}/config/%{product_name_lower}.network
+%{_datadir}/%{name}/config/%{product_name_lower}-app.container
+%{_datadir}/%{name}/config/%{product_name_lower}-celery-worker.container
+%{_datadir}/%{name}/config/%{product_name_lower}-db.container
+%{_datadir}/%{name}/config/%{product_name_lower}-redis.container
+%{_datadir}/%{name}/config/%{product_name_lower}-server.container
+%{_datadir}/%{name}/env/env-ansible.env
+%{_datadir}/%{name}/env/env-app.env
+%{_datadir}/%{name}/env/env-celery-worker.env
+%{_datadir}/%{name}/env/env-db.env
+%{_datadir}/%{name}/env/env-redis.env
+%{_datadir}/%{name}/env/env-server.env
+%{python3_sitelib}/%{name}/
+%{python3_sitelib}/%{name}-*.dist-info/
+
+%changelog
+* Fri Sep 12 2025 Alberto Bellotti <abellott@redhat.com> - 0:2.1.0-1
+- Initial version

--- a/scripts/translations.py
+++ b/scripts/translations.py
@@ -39,13 +39,13 @@ def get_code_paths() -> list:
     return code_paths
 
 
-def translations_extract():
+def translations_extract(pybabel_bin):
     """Extract gettext-wrapped strings to messages.pot template file."""
     paths: list[str] = get_code_paths()
     try:
         subprocess.check_call(  # noqa: S603
             [
-                PYBABEL_BIN,
+                pybabel_bin,
                 "extract",
                 "-o",
                 str(LOCALES_DIR / f"{DOMAIN}.pot"),
@@ -57,7 +57,7 @@ def translations_extract():
         sys.exit(1)
 
 
-def translations_update():
+def translations_update(pybabel_bin):
     """Update locale-specific .po files from the .pot template file."""
     for locale in LOCALES:
         locale_path = LOCALES_DIR / locale / "LC_MESSAGES" / f"{DOMAIN}.po"
@@ -65,7 +65,7 @@ def translations_update():
         try:
             subprocess.check_call(  # noqa: S603
                 [
-                    PYBABEL_BIN,
+                    pybabel_bin,
                     subcommand,
                     "-i",
                     str(LOCALES_DIR / f"{DOMAIN}.pot"),
@@ -82,12 +82,12 @@ def translations_update():
             sys.exit(1)
 
 
-def translations_compile():
+def translations_compile(pybabel_bin):
     """Compile locale-specific .mo files from the .po files."""
     try:
         subprocess.check_call(  # noqa: S603
             [
-                PYBABEL_BIN,
+                pybabel_bin,
                 "compile",
                 "-d",
                 str(LOCALES_DIR),
@@ -105,6 +105,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Translation management script using pybabel."
     )
+    parser.add_argument(
+        "--pybabel", type=str, required=False, help="pybabel command to use"
+    )
     subparsers = parser.add_subparsers(
         dest="command", required=True, help="Available commands"
     )
@@ -113,12 +116,13 @@ def main():
     subparsers.add_parser("compile", help="Compile binary .mo files")
     args = parser.parse_args()
 
+    pybabel_bin = pathlib.Path(args.pybabel) if args.pybabel else PYBABEL_BIN
     if args.command == "extract":
-        translations_extract()
+        translations_extract(pybabel_bin)
     elif args.command == "update":
-        translations_update()
+        translations_update(pybabel_bin)
     elif args.command == "compile":
-        translations_compile()
+        translations_compile(pybabel_bin)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""A setuptools-based script for installing quipucordsctl."""
+
+# Note: this is only used for RHEL 8 RPM builds as the
+#       pyproject-rpm-macros is not made available by default.
+#
+#       With this, we can use the older py3_build/py3_install
+#       but leverage the pyproject.toml content.
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()
+

--- a/uv.lock
+++ b/uv.lock
@@ -248,7 +248,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "podman", specifier = "==4.9.0" }]
+requires-dist = [{ name = "podman", specifier = ">=4.9.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
-  Use pybabel to compile the message catalogs to .mo files during the RPM build.

## Summary by Sourcery

Set up RPM packaging and automated Copr builds for quipucordsctl with broad OS and Python version support, include Babel build requirements, and update documentation and dependencies accordingly

New Features:
- Introduce an RPM spec for quipucordsctl supporting RHEL 8–10 and Fedora 41–43 with multiple Python versions
- Add Packit configuration for automated Copr builds on pull requests, commits to main, and releases
- Provide a setup.py fallback to enable RPM builds on RHEL 8 without pyproject-rpm-macros

Enhancements:
- Relax the podman dependency to accept any version >=4.9.0

Documentation:
- Expand README with instructions for enabling the COPR repository, installing the RPM, and running quipucordsctl