### PR TITLE
refactor: remove unused run_command "quiet" argument

### DIFF
--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -291,8 +291,8 @@ def systemctl_reload():
         _("Reloading systemctl to recognize %(server_software_name)s units"),
         {"server_software_name": settings.SERVER_SOFTWARE_NAME},
     )
-    shell_utils.run_command(SYSTEMCTL_USER_RESET_FAILED_CMD, quiet=True)
-    shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True)
+    shell_utils.run_command(SYSTEMCTL_USER_RESET_FAILED_CMD)
+    shell_utils.run_command(SYSTEMCTL_USER_DAEMON_RELOAD_CMD)
 
 
 def run(args: argparse.Namespace) -> bool:

--- a/src/quipucordsctl/podman_utils.py
+++ b/src/quipucordsctl/podman_utils.py
@@ -43,9 +43,7 @@ def ensure_podman_socket(base_url=None):
 
     if sys.platform == "darwin":
         try:
-            stdout, __, __ = shell_utils.run_command(
-                PODMAN_MACHINE_STATE_CMD, quiet=True
-            )
+            stdout, __, __ = shell_utils.run_command(PODMAN_MACHINE_STATE_CMD)
         except Exception:  # noqa: BLE001
             raise PodmanIsNotReadyError(
                 _(

--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -22,7 +22,7 @@ def confirm(prompt: str | None = None) -> bool:
     return False
 
 
-def run_command(command: list[str], *, quiet=False) -> tuple[str, str, int]:
+def run_command(command: list[str]) -> tuple[str, str, int]:
     """Run an external program."""
     logger.debug(
         _("Invoking subprocess with arguments %(command)s"), {"command": command}

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -163,8 +163,8 @@ def test_systemctl_reload(mock_shell_utils):
     install.systemctl_reload()
     mock_shell_utils.run_command.assert_has_calls(
         (
-            mock.call(install.SYSTEMCTL_USER_RESET_FAILED_CMD, quiet=True),
-            mock.call(install.SYSTEMCTL_USER_DAEMON_RELOAD_CMD, quiet=True),
+            mock.call(install.SYSTEMCTL_USER_RESET_FAILED_CMD),
+            mock.call(install.SYSTEMCTL_USER_DAEMON_RELOAD_CMD),
         )
     )
 

--- a/tests/test_podman_utils.py
+++ b/tests/test_podman_utils.py
@@ -82,7 +82,7 @@ def test_ensure_podman_socket_macos(mock_shell_utils, mock_sys, tmp_path):
         podman_utils.ensure_podman_socket()
 
     mock_shell_utils.run_command.assert_called_once_with(
-        podman_utils.PODMAN_MACHINE_STATE_CMD, quiet=True
+        podman_utils.PODMAN_MACHINE_STATE_CMD
     )
 
 
@@ -106,7 +106,7 @@ def test_ensure_podman_socket_macos_not_running(mock_shell_utils, mock_sys, tmp_
             raise e
 
     mock_shell_utils.run_command.assert_called_once_with(
-        podman_utils.PODMAN_MACHINE_STATE_CMD, quiet=True
+        podman_utils.PODMAN_MACHINE_STATE_CMD
     )
 
 
@@ -130,7 +130,7 @@ def test_ensure_podman_socket_macos_broken(mock_shell_utils, mock_sys, tmp_path)
             raise e
 
     mock_shell_utils.run_command.assert_called_once_with(
-        podman_utils.PODMAN_MACHINE_STATE_CMD, quiet=True
+        podman_utils.PODMAN_MACHINE_STATE_CMD
     )
 
 


### PR DESCRIPTION
This one slipped by me when I made some late fixes to the "install" command and removed the behavior that was driven by "quiet" that turned it into a useless argument.