### PR TITLE
feat: implement the check command

### DIFF
--- a/src/quipucordsctl/commands/check.py
+++ b/src/quipucordsctl/commands/check.py
@@ -1,0 +1,303 @@
+"""Check that all necessary files and directories exist for running Quipucords."""
+
+import argparse
+import getpass
+import logging
+import os
+import pathlib
+import stat
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from gettext import gettext as _
+from typing import Optional
+
+from quipucordsctl import settings
+
+logger = logging.getLogger(__name__)
+
+
+class StatusType(Enum):
+    """Enumeration of possible path status types."""
+
+    OK = "ok"
+    BAD_PERMISSIONS = "bad_permissions"
+    WRONG_OWNER = "wrong_owner"
+    MISSING = "missing"
+
+
+@dataclass
+class PathCheckResult:
+    """Result of checking a path's status."""
+
+    status: StatusType
+    path: pathlib.Path
+    stat_info: Optional[os.stat_result] = None
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _(
+        "Check that all necessary files and directories exist for running "
+        "%(server_software_name)s."
+    ) % {"server_software_name": settings.SERVER_SOFTWARE_NAME}
+
+
+def check_directory_status(path: pathlib.Path) -> PathCheckResult:
+    """
+    Check the status of a directory.
+
+    Returns:
+        PathCheckResult with status indicating OK, bad permissions, wrong owner, or
+        missing.
+    """
+    try:
+        if not path.exists():
+            return PathCheckResult(StatusType.MISSING, path)
+
+        if not path.is_dir():
+            return PathCheckResult(StatusType.MISSING, path)
+
+        path_stat = path.stat()
+
+        # Check ownership - should be owned by current user
+        if path_stat.st_uid != os.getuid():
+            return PathCheckResult(StatusType.WRONG_OWNER, path, path_stat)
+
+        # Check permissions - should be readable and writable by owner
+        mode = path_stat.st_mode
+        if not (mode & stat.S_IRUSR and mode & stat.S_IWUSR):
+            return PathCheckResult(StatusType.BAD_PERMISSIONS, path, path_stat)
+
+        return PathCheckResult(StatusType.OK, path, path_stat)
+
+    except PermissionError:
+        return PathCheckResult(StatusType.BAD_PERMISSIONS, path)
+
+
+def check_file_status(path: pathlib.Path) -> PathCheckResult:
+    """
+    Check the status of a file.
+
+    Returns:
+        PathCheckResult with status indicating OK, bad permissions, wrong owner, or
+        missing.
+    """
+    try:
+        if not path.exists():
+            return PathCheckResult(StatusType.MISSING, path)
+
+        if not path.is_file():
+            return PathCheckResult(StatusType.MISSING, path)
+
+        path_stat = path.stat()
+
+        # Check ownership - should be owned by current user
+        if path_stat.st_uid != os.getuid():
+            return PathCheckResult(StatusType.WRONG_OWNER, path, path_stat)
+
+        # Check permissions - should be readable and writable by owner
+        mode = path_stat.st_mode
+        if not (mode & stat.S_IRUSR and mode & stat.S_IWUSR):
+            return PathCheckResult(StatusType.BAD_PERMISSIONS, path, path_stat)
+
+        return PathCheckResult(StatusType.OK, path, path_stat)
+
+    except PermissionError:
+        return PathCheckResult(StatusType.BAD_PERMISSIONS, path)
+
+
+def _log_ok_status(result: PathCheckResult) -> None:
+    """Log OK status with detailed info if available."""
+    try:
+        if result.stat_info:
+            logger.info(
+                _("%(path)s: OK: %(perms)s %(owner)s"),
+                {
+                    "path": result.path,
+                    "perms": stat.filemode(result.stat_info.st_mode),
+                    "owner": result.path.owner(),
+                },
+            )
+            return
+    except (OSError, KeyError) as error:
+        logger.error(
+            _("Unexpected error reporting status of %(path)s: %(error)s"),
+            {"path": result.path, "error": error},
+        )
+    logger.info(_("%(path)s: OK"), {"path": result.path})
+
+
+def _log_bad_permissions_status(result: PathCheckResult) -> None:
+    """Log bad permissions status with detailed info if available."""
+    try:
+        if result.stat_info:
+            logger.error(
+                _("%(path)s: ERROR: Incorrect permission(s): %(perms)s"),
+                {
+                    "path": result.path,
+                    "perms": stat.filemode(result.stat_info.st_mode),
+                },
+            )
+            return
+    except OSError as error:
+        logger.error(
+            _("Unexpected error reporting status of %(path)s: %(error)s"),
+            {"path": result.path, "error": error},
+        )
+    logger.error(_("%(path)s: ERROR: Incorrect permissions"), {"path": result.path})
+
+
+def _log_wrong_owner_status(result: PathCheckResult) -> None:
+    """Log wrong owner status with detailed info if available."""
+    try:
+        if result.stat_info:
+            logger.error(
+                _(
+                    "%(path)s: ERROR: Not owned by you (incorrect ownership): "
+                    "%(uid)s %(owner)s"
+                ),
+                {
+                    "path": result.path,
+                    "user": getpass.getuser(),
+                    "uid": result.stat_info.st_uid,
+                    "owner": result.path.owner(),
+                },
+            )
+            return
+    except (OSError, KeyError) as error:
+        logger.error(
+            _("Unexpected error reporting status of %(path)s: %(error)s"),
+            {"path": result.path, "error": error},
+        )
+    logger.error(
+        _("%(path)s: ERROR: Not owned by you (incorrect ownership)"),
+        {"path": result.path},
+    )
+
+
+def log_path_status(result: PathCheckResult) -> None:
+    """Print the status of a path in a user-friendly format."""
+    if result.status == StatusType.OK:
+        _log_ok_status(result)
+    elif result.status == StatusType.BAD_PERMISSIONS:
+        _log_bad_permissions_status(result)
+    elif result.status == StatusType.WRONG_OWNER:
+        _log_wrong_owner_status(result)
+    elif result.status == StatusType.MISSING:
+        logger.error(_("%(path)s: ERROR: Missing"), {"path": result.path})
+    else:
+        logger.error(_("%(path)s: ERROR: Unknown status"), {"path": result.path})
+
+
+def check_directory_and_print_status(path: pathlib.Path) -> bool:
+    """Check a directory status and print the result.
+
+    Returns True if OK, False if there's an issue.
+    """
+    result = check_directory_status(path)
+    log_path_status(result)
+    return result.status == StatusType.OK
+
+
+def check_file_and_print_status(path: pathlib.Path) -> bool:
+    """Check a file status and print the result.
+
+    Returns True if OK, False if there's an issue.
+    """
+    result = check_file_status(path)
+    log_path_status(result)
+    return result.status == StatusType.OK
+
+
+def _check_data_directories() -> int:
+    """Check main data directory and subdirectories. Returns error count."""
+    error_count = 0
+
+    # Check main data directory
+    if not check_directory_and_print_status(settings.SERVER_DATA_DIR):
+        error_count += 1
+
+    # Check data subdirectories
+    for subdir_path in settings.SERVER_DATA_SUBDIRS.values():
+        if not check_directory_and_print_status(subdir_path):
+            error_count += 1
+
+    # Check database userdata directory (special case)
+    db_userdata_dir = settings.SERVER_DATA_DIR / "db" / "userdata"
+    if not check_directory_and_print_status(db_userdata_dir):
+        error_count += 1
+
+    return error_count
+
+
+def _check_required_files() -> int:
+    """Check specific files that should exist. Returns error count."""
+    error_count = 0
+
+    specific_files = [
+        settings.SERVER_DATA_DIR / "certs" / "server.key",
+        settings.SERVER_DATA_DIR / "certs" / "server.crt",
+    ]
+
+    for file_path in specific_files:
+        if not check_file_and_print_status(file_path):
+            error_count += 1
+
+    return error_count
+
+
+def _check_configuration_directories() -> int:
+    """Check configuration directories. Returns error count."""
+    error_count = 0
+
+    if not check_directory_and_print_status(settings.SERVER_ENV_DIR):
+        error_count += 1
+
+    if not check_directory_and_print_status(settings.SYSTEMD_UNITS_DIR):
+        error_count += 1
+
+    return error_count
+
+
+def _check_configuration_files() -> int:
+    """Check environment and systemd unit files. Returns error count."""
+    error_count = 0
+
+    # Check environment files
+    for env_filename in settings.TEMPLATE_SERVER_ENV_FILENAMES:
+        env_file_path = settings.SERVER_ENV_DIR / env_filename
+        if not check_file_and_print_status(env_file_path):
+            error_count += 1
+
+    # Check systemd unit files
+    for unit_filename in settings.TEMPLATE_SYSTEMD_UNITS_FILENAMES:
+        unit_file_path = settings.SYSTEMD_UNITS_DIR / unit_filename
+        if not check_file_and_print_status(unit_file_path):
+            error_count += 1
+
+    return error_count
+
+
+def run(args: argparse.Namespace) -> bool:
+    """Run the check command."""
+    logger.info(
+        _("Checking %(server_software_name)s setup and configurations..."),
+        {"server_software_name": settings.SERVER_SOFTWARE_NAME},
+    )
+
+    error_count = 0
+    error_count += _check_data_directories()
+    error_count += _check_required_files()
+    error_count += _check_configuration_directories()
+    error_count += _check_configuration_files()
+
+    # Return success if no errors, otherwise exit with count of issues
+    # This matches the acceptance criteria: "returns 0 on success or the positive
+    # number of unexpected states it encountered"
+    if error_count == 0:
+        logger.info(_("All checks passed successfully."))
+        return True
+    else:
+        logger.error(_("Found %(error_count)d issues."), {"error_count": error_count})
+        sys.exit(error_count)

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -1,0 +1,380 @@
+"""Test the "check" command."""
+
+import logging
+import pathlib
+import stat
+from unittest import mock
+
+import pytest
+
+from quipucordsctl import settings
+from quipucordsctl.commands import check
+from quipucordsctl.commands.check import PathCheckResult, StatusType
+
+
+def test_check_directory_status_missing(tmp_path: pathlib.Path):
+    """Test check_directory_status returns MISSING for missing directory."""
+    missing_dir = tmp_path / "missing_directory"
+    result = check.check_directory_status(missing_dir)
+    assert result.status == StatusType.MISSING
+    assert result.path == missing_dir
+    assert result.stat_info is None
+
+
+def test_check_directory_status_not_directory(tmp_path: pathlib.Path):
+    """Test check_directory_status returns MISSING when path is file, not directory."""
+    file_path = tmp_path / "is_a_file"
+    file_path.touch()
+    result = check.check_directory_status(file_path)
+    assert result.status == StatusType.MISSING
+    assert result.path == file_path
+    assert result.stat_info is None
+
+
+def test_check_directory_status_ok(tmp_path: pathlib.Path):
+    """Test check_directory_status returns OK for valid directory."""
+    valid_dir = tmp_path / "valid_directory"
+    valid_dir.mkdir()
+    result = check.check_directory_status(valid_dir)
+    assert result.status == StatusType.OK
+    assert result.path == valid_dir
+    assert result.stat_info is not None
+
+
+def test_check_directory_status_bad_permissions(tmp_path: pathlib.Path):
+    """Test check_directory_status returns BAD_PERMISSIONS for directory."""
+    bad_perms_dir = tmp_path / "bad_perms_directory"
+    bad_perms_dir.mkdir()
+    bad_perms_dir.chmod(stat.S_IWUSR | stat.S_IXUSR)
+    try:
+        result = check.check_directory_status(bad_perms_dir)
+        assert result.status == StatusType.BAD_PERMISSIONS
+        assert result.path == bad_perms_dir
+        assert result.stat_info is not None
+    finally:
+        # Reset permissions so pytest can clean up
+        bad_perms_dir.chmod(0o755)
+
+
+def test_check_file_status_missing(tmp_path: pathlib.Path):
+    """Test check_file_status returns MISSING for missing file."""
+    missing_file = tmp_path / "missing_file.txt"
+    result = check.check_file_status(missing_file)
+    assert result.status == StatusType.MISSING
+    assert result.path == missing_file
+    assert result.stat_info is None
+
+
+def test_check_file_status_not_file(tmp_path: pathlib.Path):
+    """Test check_file_status returns MISSING when path is a directory, not file."""
+    dir_path = tmp_path / "is_a_directory"
+    dir_path.mkdir()
+    result = check.check_file_status(dir_path)
+    assert result.status == StatusType.MISSING
+    assert result.path == dir_path
+    assert result.stat_info is None
+
+
+def test_check_file_status_ok(tmp_path: pathlib.Path):
+    """Test check_file_status returns OK for valid file."""
+    valid_file = tmp_path / "valid_file.txt"
+    valid_file.touch()
+    result = check.check_file_status(valid_file)
+    assert result.status == StatusType.OK
+    assert result.path == valid_file
+    assert result.stat_info is not None
+
+
+def test_check_file_status_bad_permissions(tmp_path: pathlib.Path):
+    """Test check_file_status returns BAD_PERMISSIONS for file with bad permissions."""
+    bad_perms_file = tmp_path / "bad_perms_file.txt"
+    bad_perms_file.touch()
+    bad_perms_file.chmod(stat.S_IWUSR)
+    try:
+        result = check.check_file_status(bad_perms_file)
+        assert result.status == StatusType.BAD_PERMISSIONS
+        assert result.path == bad_perms_file
+        assert result.stat_info is not None
+    finally:
+        # Reset permissions for cleanup
+        bad_perms_file.chmod(0o644)
+
+
+def test_log_path_status_ok(caplog, tmp_path: pathlib.Path):
+    """Test log_path_status with OK status."""
+    caplog.set_level(logging.INFO)
+    test_path = tmp_path / "test_path"
+    test_path.touch()
+
+    result = PathCheckResult(StatusType.OK, test_path, test_path.stat())
+    check.log_path_status(result)
+
+    assert len(caplog.messages) == 1
+    assert "OK" in caplog.messages[0]
+    assert str(test_path) in caplog.messages[0]
+
+
+def test_log_path_status_missing(caplog, tmp_path: pathlib.Path):
+    """Test log_path_status with MISSING status."""
+    caplog.set_level(logging.ERROR)
+    test_path = tmp_path / "missing_path"
+
+    result = PathCheckResult(StatusType.MISSING, test_path)
+    check.log_path_status(result)
+
+    assert len(caplog.messages) == 1
+    assert "ERROR: Missing" in caplog.messages[0]
+    assert str(test_path) in caplog.messages[0]
+
+
+def test_log_path_status_bad_permissions(caplog, tmp_path: pathlib.Path):
+    """Test log_path_status with BAD_PERMISSIONS status."""
+    caplog.set_level(logging.ERROR)
+    test_path = tmp_path / "bad_perms_path"
+    test_path.touch()
+    test_path.chmod(stat.S_IWUSR)
+    try:
+        result = PathCheckResult(
+            StatusType.BAD_PERMISSIONS, test_path, test_path.stat()
+        )
+        check.log_path_status(result)
+        assert len(caplog.messages) == 1
+        assert "ERROR: Incorrect permission(s)" in caplog.messages[0]
+        assert str(test_path) in caplog.messages[0]
+    finally:
+        test_path.chmod(0o644)
+
+
+def test_log_path_status_not_owned(caplog, tmp_path: pathlib.Path):
+    """Test log_path_status with WRONG_OWNER status."""
+    caplog.set_level(logging.ERROR)
+    test_path = tmp_path / "not_owned_path"
+    test_path.touch()
+
+    result = PathCheckResult(StatusType.WRONG_OWNER, test_path, test_path.stat())
+    check.log_path_status(result)
+
+    assert len(caplog.messages) == 1
+    assert "ERROR: Not owned by you" in caplog.messages[0]
+    assert str(test_path) in caplog.messages[0]
+
+
+def test_log_path_status_unknown(caplog, tmp_path: pathlib.Path):
+    """Test log_path_status with unknown status (should not happen in practice)."""
+    caplog.set_level(logging.ERROR)
+    test_path = tmp_path / "test_path"
+
+    # Create a mock status that's not one of our enum values
+    class MockStatus:
+        pass
+
+    result = PathCheckResult(MockStatus(), test_path)
+    check.log_path_status(result)
+
+    assert len(caplog.messages) == 1
+    assert "ERROR: Unknown status" in caplog.messages[0]
+    assert str(test_path) in caplog.messages[0]
+
+
+def create_full_quipucords_structure(temp_dirs: dict[str, pathlib.Path]) -> None:
+    """Create a complete, valid Quipucords directory structure."""
+    for dir_path in temp_dirs.values():
+        dir_path.mkdir(parents=True, exist_ok=True)
+
+    for subdir_name in ("certs", "data", "db", "log", "sshkeys"):
+        subdir_path = temp_dirs["SERVER_DATA_DIR"] / subdir_name
+        subdir_path.mkdir(parents=True, exist_ok=True)
+
+    (temp_dirs["SERVER_DATA_DIR"] / "certs" / "server.key").touch()
+    (temp_dirs["SERVER_DATA_DIR"] / "certs" / "server.crt").touch()
+
+    (temp_dirs["SERVER_DATA_DIR"] / "db" / "userdata").mkdir(
+        parents=True, exist_ok=True
+    )
+
+    for env_filename in settings.TEMPLATE_SERVER_ENV_FILENAMES:
+        (temp_dirs["SERVER_ENV_DIR"] / env_filename).touch()
+
+    for unit_filename in settings.TEMPLATE_SYSTEMD_UNITS_FILENAMES:
+        (temp_dirs["SYSTEMD_UNITS_DIR"] / unit_filename).touch()
+
+
+def test_run_all_files_missing(
+    temp_config_directories: dict[str, pathlib.Path], caplog
+):
+    """Test run when all files and directories are missing."""
+    caplog.set_level(logging.INFO)
+    mock_args = mock.Mock()
+
+    with pytest.raises(SystemExit) as exc_info:
+        check.run(mock_args)
+
+    expected_error_count = 23
+    assert exc_info.value.code == expected_error_count
+
+    error_messages = [
+        msg for msg in caplog.messages if "Found" in msg and "issues" in msg
+    ]
+    assert len(error_messages) == 1
+    assert f"Found {expected_error_count} issues" in error_messages[0]
+
+
+def test_run_all_files_present_and_valid(
+    temp_config_directories: dict[str, pathlib.Path], caplog
+):
+    """Test run when all files and directories are present and valid."""
+    caplog.set_level(logging.INFO)
+    mock_args = mock.Mock()
+
+    create_full_quipucords_structure(temp_config_directories)
+
+    result = check.run(mock_args)
+
+    assert result is True
+
+    success_messages = [
+        msg for msg in caplog.messages if "All checks passed successfully" in msg
+    ]
+    assert len(success_messages) == 1
+
+
+def test_run_some_files_missing(
+    temp_config_directories: dict[str, pathlib.Path], caplog
+):
+    """Test run when some files are missing."""
+    caplog.set_level(logging.INFO)
+    mock_args = mock.Mock()
+
+    temp_config_directories["SERVER_DATA_DIR"].mkdir(parents=True, exist_ok=True)
+    (temp_config_directories["SERVER_DATA_DIR"] / "certs").mkdir(
+        parents=True, exist_ok=True
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        check.run(mock_args)
+
+    assert exc_info.value.code > 0
+
+    error_messages = [msg for msg in caplog.messages if "ERROR: Missing" in msg]
+    assert len(error_messages) > 0
+
+
+def test_run_permission_issues(
+    temp_config_directories: dict[str, pathlib.Path], caplog
+):
+    """Test run when files exist but have permission issues."""
+    caplog.set_level(logging.INFO)
+    mock_args = mock.Mock()
+
+    create_full_quipucords_structure(temp_config_directories)
+
+    server_key = temp_config_directories["SERVER_DATA_DIR"] / "certs" / "server.key"
+    server_key.chmod(0o000)  # No permissions at all
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            check.run(mock_args)
+        assert exc_info.value.code > 0
+
+        permission_errors = [
+            msg for msg in caplog.messages if "Incorrect permission" in msg
+        ]
+        assert len(permission_errors) > 0
+    finally:
+        # Reset permissions to allow pytest cleanup
+        server_key.chmod(0o644)
+
+
+def test_check_directory_and_print_status_returns_correct_status(
+    tmp_path: pathlib.Path,
+):
+    """Test that check_directory_and_print_status returns False for missing dir."""
+    missing_dir = tmp_path / "missing"
+
+    with mock.patch.object(check, "log_path_status") as mock_log:
+        result = check.check_directory_and_print_status(missing_dir)
+
+        assert result is False  # Missing directory should return False
+        mock_log.assert_called_once()
+        # Verify the PathCheckResult passed to log_path_status
+        call_args = mock_log.call_args[0][0]
+        assert call_args.status == StatusType.MISSING
+        assert call_args.path == missing_dir
+
+
+def test_check_file_and_print_status_returns_correct_status(tmp_path: pathlib.Path):
+    """Test that check_file_and_print_status returns False for missing file."""
+    missing_file = tmp_path / "missing.txt"
+
+    with mock.patch.object(check, "log_path_status") as mock_log:
+        result = check.check_file_and_print_status(missing_file)
+
+        assert result is False  # Missing file should return False
+        mock_log.assert_called_once()
+        # Verify the PathCheckResult passed to log_path_status
+        call_args = mock_log.call_args[0][0]
+        assert call_args.status == StatusType.MISSING
+        assert call_args.path == missing_file
+
+
+def test_get_help():
+    """Test that get_help returns expected help text."""
+    help_text = check.get_help()
+    assert "Check that all necessary files and directories exist" in help_text
+    assert settings.SERVER_SOFTWARE_NAME in help_text
+
+
+def test_check_directory_status_with_permission_error(tmp_path: pathlib.Path):
+    """Test check_directory_status when stat() raises PermissionError."""
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    with mock.patch.object(pathlib.Path, "stat", side_effect=PermissionError):
+        result = check.check_directory_status(test_dir)
+        assert result.status == StatusType.BAD_PERMISSIONS
+        assert result.path == test_dir
+        assert result.stat_info is None
+
+
+def test_check_file_status_with_permission_error(tmp_path: pathlib.Path):
+    """Test check_file_status when stat() raises PermissionError."""
+    test_file = tmp_path / "test_file.txt"
+    test_file.touch()
+
+    with mock.patch.object(pathlib.Path, "stat", side_effect=PermissionError):
+        result = check.check_file_status(test_file)
+        assert result.status == StatusType.BAD_PERMISSIONS
+        assert result.path == test_file
+        assert result.stat_info is None
+
+
+def test_log_path_status_handles_stat_errors_gracefully(caplog, tmp_path: pathlib.Path):
+    """Test that log_path_status handles stat() errors gracefully."""
+    caplog.set_level(logging.ERROR)
+    test_path = tmp_path / "test_path"
+    test_path.touch()
+
+    # Create result with stat_info=None to simulate error during stat capture
+    result = PathCheckResult(StatusType.BAD_PERMISSIONS, test_path, None)
+    check.log_path_status(result)
+
+    assert len(caplog.messages) == 1
+    assert "ERROR: Incorrect permissions" in caplog.messages[0]
+
+
+@pytest.mark.parametrize("owner_method_error", [OSError, KeyError])
+def test_log_path_status_handles_owner_errors(
+    owner_method_error, caplog, tmp_path: pathlib.Path
+):
+    """Test that log_path_status handles Path.owner() errors gracefully."""
+    caplog.set_level(logging.INFO)
+    test_path = tmp_path / "test_path"
+    test_path.touch()
+
+    result = PathCheckResult(StatusType.OK, test_path, test_path.stat())
+    with mock.patch.object(pathlib.Path, "owner", side_effect=owner_method_error):
+        check.log_path_status(result)
+
+    assert len(caplog.messages) == 2
+    assert "Unexpected error reporting status" in caplog.messages[0]
+    assert "OK" in caplog.messages[1]

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -2,9 +2,7 @@
 
 import logging
 import pathlib
-from collections.abc import Generator
 from importlib import resources
-from typing import Any
 from unittest import mock
 
 import pytest
@@ -12,28 +10,6 @@ import pytest
 from quipucordsctl import settings
 from quipucordsctl.commands import install
 from quipucordsctl.systemdunitparser import SystemdUnitParser
-
-
-@pytest.fixture
-def temp_config_directories(
-    tmp_path: pathlib.Path, monkeypatch
-) -> Generator[dict[str, pathlib.Path], Any, None]:
-    """Temporarily swap any directories the "install" command would touch."""
-    temp_settings_dirs = {}
-    for settings_dir in ("SERVER_DATA_DIR", "SERVER_ENV_DIR", "SYSTEMD_UNITS_DIR"):
-        new_path = tmp_path / settings_dir
-        monkeypatch.setattr(
-            f"quipucordsctl.commands.install.settings.{settings_dir}", new_path
-        )
-        temp_settings_dirs[settings_dir] = new_path
-    tmp_data_dirs = {
-        data_dir: temp_settings_dirs["SERVER_DATA_DIR"] / data_dir
-        for data_dir in ("data", "db", "log", "sshkeys")
-    }
-    monkeypatch.setattr(
-        "quipucordsctl.commands.install.settings.SERVER_DATA_SUBDIRS", tmp_data_dirs
-    )
-    yield temp_settings_dirs
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,52 @@
 """Shared fixtures for pytest tests."""
 
+import importlib
+import pathlib
+import pkgutil
+from collections.abc import Generator
+from typing import Any
+
 import pytest
+
+
+@pytest.fixture
+def temp_config_directories(
+    tmp_path: pathlib.Path, monkeypatch
+) -> Generator[dict[str, pathlib.Path], Any, None]:
+    """Temporarily swap config directories for ALL commands that need them."""
+    temp_settings_dirs = {}
+
+    # Create temp directories
+    for settings_dir in ("SERVER_DATA_DIR", "SERVER_ENV_DIR", "SYSTEMD_UNITS_DIR"):
+        new_path = tmp_path / settings_dir
+        temp_settings_dirs[settings_dir] = new_path
+
+    commands_package = importlib.import_module("quipucordsctl.commands")
+    command_names = [
+        module_info.name for module_info in pkgutil.iter_modules(
+            commands_package.__path__
+        )
+    ]
+    for command in command_names:
+        for settings_dir in ("SERVER_DATA_DIR", "SERVER_ENV_DIR", "SYSTEMD_UNITS_DIR"):
+            monkeypatch.setattr(
+                f"quipucordsctl.commands.{command}.settings.{settings_dir}",
+                temp_settings_dirs[settings_dir],
+            )
+
+    # Handle SERVER_DATA_SUBDIRS (include 'certs' for maximum compatibility)
+    tmp_data_dirs = {
+        data_dir: temp_settings_dirs["SERVER_DATA_DIR"] / data_dir
+        for data_dir in ("certs", "data", "db", "log", "sshkeys")  # Include all
+    }
+
+    for command in command_names:
+        monkeypatch.setattr(
+            f"quipucordsctl.commands.{command}.settings.SERVER_DATA_SUBDIRS",
+            tmp_data_dirs,
+        )
+
+    yield temp_settings_dirs
 
 
 @pytest.fixture


### PR DESCRIPTION
- Implement check command that verifies existence and permissions of
  required files/directories for Quipucords installation
- Returns 0 on success or positive count of issues encountered
  (matching acceptance criteria from quipucords-installer)
- Checks data directories (certs, data, db, log, sshkeys),
  configuration files, and systemd units
- add unit tests 

## Summary by Sourcery

Add a new "check" command to validate that all required Quipucords files and directories exist, are owned by the current user, and have appropriate permissions, exiting with the number of issues found if any.

New Features:
- Implement check_directory_status and check_file_status to report missing, ownership, or permission issues for paths
- Add print_path_status to log human-readable status messages for files and directories
- Add run function to orchestrate full-system validation and exit with issue count when checks fail
- Provide get_help for command usage description

Enhancements:
- Gracefully handle PermissionError, OSError, and owner lookup errors during status checks and logging

Tests:
- Add extensive unit tests covering directory and file status checks, logging output for various statuses, and run command scenarios for missing, valid, and permission-error setups
- Introduce fixtures to simulate temporary configuration directories for test isolation

## Summary by Sourcery

Implement a new check command that verifies required Quipucords files and directories exist, are owned by the current user, and have correct permissions, reporting any issues and exiting with the issue count.

New Features:
- Implement check_directory_status and check_file_status to validate existence, ownership, and permissions of file system paths
- Introduce print_path_status to emit human-readable status logs for file and directory checks
- Add run function to orchestrate full Quipucords installation validation and exit with the count of issues
- Provide get_help method for command usage description

Enhancements:
- Handle PermissionError, OSError, and owner lookup errors gracefully during status checks and logging

Tests:
- Add unit tests for directory and file status functions covering missing, type mismatch, permission, and ownership scenarios
- Add tests for print_path_status formatting across all status codes and error conditions
- Add run command tests for all-missing, all-valid, partial-missing, and permission-error states with fixtures for isolated temporary directory setups
- Add test for get_help output including server software name