### PR TITLE
fix(check): allow files generated during startup to be missing

### DIFF
--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -43,3 +43,24 @@ def reload_daemon() -> bool:
     shell_utils.run_command(settings.SYSTEMCTL_USER_RESET_FAILED_CMD)
     shell_utils.run_command(settings.SYSTEMCTL_USER_DAEMON_RELOAD_CMD)
     return True
+
+
+def check_service_running() -> bool:
+    """Check if quipucords-app service is currently running."""
+    logger.debug(
+        _("Checking if %(server_software_name)s service is active"),
+        {
+            "server_software_name": settings.SERVER_SOFTWARE_NAME,
+        },
+    )
+    __, __, status_exit = shell_utils.run_command(
+        [
+            "systemctl",
+            "-q",
+            "--user",
+            "is-active",
+            f"{settings.SERVER_SOFTWARE_PACKAGE}-app.service",
+        ],
+        raise_error=False,
+    )
+    return status_exit == 0


### PR DESCRIPTION
Some files are generated during containers startup. If we run `quipucordsctl check` after install but before starting systemd units, it's OK they are missing.

We check `quipucords-app.service` status as a proxy for "were systemd units started". Technically this is not correct, as user may start units, stop them and manually remove one of files. But we don't want to keep track of whether units were ever started.

Relates to JIRA: DISCOVERY-1134

## Summary by Sourcery

Allow checks to treat paths generated at startup as non-fatal by introducing an OK_MISSING status, wiring a missing_ok flag through the check logic, and detecting server running state to apply this behavior accordingly.

Enhancements:
- Allow certain files and directories to be missing before the server starts by introducing a new OK_MISSING status
- Add a missing_ok parameter to file and directory check functions and treat OK_MISSING as a successful check
- Detect service running state via systemctl in run(), and pass that state to control missing_ok behavior in checks

Tests:
- Parameterize tests for missing_ok scenarios and add coverage for OK_MISSING logging
- Mock run_command in tests to simulate service running state during checks