### PR TITLE
Remove Fedora 41 from packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,8 +18,6 @@ jobs:
       - rhel-10-x86_64
       - rhel-10-aarch64
       # and also build on Fedora as an early preview of future releases.
-      - fedora-41-x86_64
-      - fedora-41-aarch64
       - fedora-42-x86_64
       - fedora-42-aarch64
 


### PR DESCRIPTION
Fedora 41 is scheduled to EOL today. Packit and copr are going to remove support soon enough.

## Summary by Sourcery

Chores:
- Drop fedora-41-x86_64 and fedora-41-aarch64 entries from .packit.yaml