### PR TITLE
feat: Bail out loudly when systemd user session is not available

### DIFF
--- a/src/quipucordsctl/cli.py
+++ b/src/quipucordsctl/cli.py
@@ -8,7 +8,7 @@ import sys
 from gettext import gettext as _
 from types import ModuleType
 
-from . import podman_utils, settings
+from . import podman_utils, settings, systemctl_utils
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +134,11 @@ def run():
             sys.exit(1)
         except podman_utils.PodmanIsNotReadyError as e:
             # can occur if podman is not available or running
+            print()
+            logger.error(e)
+            sys.exit(1)
+        except systemctl_utils.NoSystemdUserSessionError as e:
+            # systemctl user session is not available
             print()
             logger.error(e)
             sys.exit(1)

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -11,7 +11,7 @@ import types
 from datetime import datetime
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, settings, shell_utils
+from quipucordsctl import podman_utils, settings, shell_utils, systemctl_utils
 from quipucordsctl.commands import (
     reset_admin_password,
     reset_database_password,
@@ -312,6 +312,7 @@ def run(args: argparse.Namespace) -> bool:
     logger.debug("Starting install command")
     podman_utils.ensure_podman_socket()
     podman_utils.ensure_cgroups_v2()
+    systemctl_utils.ensure_systemd_user_session()
 
     if not reset_secrets(args):
         return False

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -62,6 +62,7 @@ SYSTEMD_SERVICE_FILENAMES = (
 # System commands commonly run
 SYSTEMCTL_USER_RESET_FAILED_CMD = ["systemctl", "--user", "reset-failed"]
 SYSTEMCTL_USER_DAEMON_RELOAD_CMD = ["systemctl", "--user", "daemon-reload"]
+SYSTEMCTL_USER_IS_SYSTEM_RUNNING_CMD = ["systemctl", "--user", "is-system-running"]
 SYSTEMCTL_USER_LIST_QUIPUCORDS_APP = [
     "systemctl",
     "-q",

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -61,6 +61,7 @@ def test_install_run(
     systemd_dir = temp_config_directories["SYSTEMD_UNITS_DIR"]
     with (
         mock.patch.object(install, "podman_utils") as podman_utils,
+        mock.patch.object(install, "systemctl_utils") as systemctl_utils,
         mock.patch.object(install, "reset_secrets") as reset_secrets,
         mock.patch.object(install, "systemctl_reload") as systemctl_reload,
     ):
@@ -70,6 +71,7 @@ def test_install_run(
 
         podman_utils.ensure_podman_socket.assert_called_once()
         podman_utils.ensure_cgroups_v2.assert_called_once()
+        systemctl_utils.ensure_systemd_user_session.assert_called_once()
         reset_secrets.assert_called_once_with(mock_args)
         systemctl_reload.assert_called_once()
 


### PR DESCRIPTION
The acceptance criteria called for "preflight validation before executing user commands", but I decided to follow established pattern and only do that in `install`. E.g. we don't call `podman_utils.ensure_podman_socket()` when we attempt to create podman secrets (probably under the assumptions that secret creation happens after install checks).

Relates to JIRA: DISCOVERY-1163

## Summary by Sourcery

Add a preflight check to ensure a valid systemd user session before running the install command and surface clear errors when the environment is misconfigured.

New Features:
- Introduce a systemd user session validation step during installation to detect misconfigured environments early.

Enhancements:
- Add a dedicated exception type for missing systemd user sessions and handle it explicitly in the CLI error flow.

Tests:
- Extend install and systemd utility tests to cover systemd user session validation behavior.