### PR TITLE
Cross-check username and password similarity

### DIFF
--- a/src/quipucordsctl/shell_utils.py
+++ b/src/quipucordsctl/shell_utils.py
@@ -71,7 +71,7 @@ def env_template_dir() -> pathlib.Path:
     return template_dir().joinpath("env")
 
 
-def run_command(  # noqa: C901, PLR0913
+def run_command(  # noqa: C901, PLR0913, PLR0912
     command: list[str],
     *,
     raise_error: bool = True,
@@ -80,6 +80,7 @@ def run_command(  # noqa: C901, PLR0913
     stdout=None,
     stderr=None,
     env: dict[str, str] | None = None,
+    redact_output: bool = False,
     **kwargs,
 ) -> tuple[str, str, int]:
     """Run an external program."""
@@ -139,11 +140,17 @@ def run_command(  # noqa: C901, PLR0913
     stdout_logger = logger.debug if exit_code == 0 else logger.info
     stderr_logger = logger.debug if exit_code == 0 else logger.error
     if stdout == subprocess.PIPE:
-        for line in stdout.strip().splitlines():
-            stdout_logger(line)
+        if redact_output:
+            stdout_logger(_("[output redacted for security]"))
+        else:
+            for line in stdout.strip().splitlines():
+                stdout_logger(line)
     if stderr == subprocess.PIPE:
-        for line in stderr.strip().splitlines():
-            stderr_logger(line)
+        if redact_output:
+            stderr_logger(_("[output redacted for security]"))
+        else:
+            for line in stderr.strip().splitlines():
+                stderr_logger(line)
 
     if raise_error and exit_code != 0:
         logger.error(

--- a/tests/commands/test_reset_admin_password.py
+++ b/tests/commands/test_reset_admin_password.py
@@ -4,6 +4,8 @@ import argparse
 import logging
 from unittest import mock
 
+import pytest
+
 from quipucordsctl.commands import reset_admin_password
 from tests.conftest import assert_reset_command_help
 
@@ -84,3 +86,113 @@ def test_reset_admin_password_run_unexpected_failure(
 
     assert not reset_admin_password.run(argparse.Namespace())
     assert expected_last_log_message == caplog.messages[0]
+
+
+@mock.patch.object(reset_admin_password.secrets, "build_similar_value_check")
+@mock.patch.object(reset_admin_password.secrets, "reset_secret")
+def test_reset_admin_password_builds_similarity_check_when_username_exists(
+    mock_reset_secret, mock_build_check, faker
+):
+    """Test run() builds similarity check when username secret exists."""
+    mock_similar_check = mock.Mock()
+    mock_build_check.return_value = mock_similar_check
+    mock_reset_secret.return_value = True
+
+    reset_admin_password.run(argparse.Namespace())
+
+    mock_build_check.assert_called_once_with(
+        secret_name=reset_admin_password.USERNAME_SECRET_NAME,
+        display_name="admin login username",
+    )
+
+    call_kwargs = mock_reset_secret.call_args.kwargs
+    assert call_kwargs["check_requirements"]["check_similar"] == mock_similar_check
+
+
+@mock.patch.object(reset_admin_password.secrets, "build_similar_value_check")
+@mock.patch.object(reset_admin_password.secrets, "reset_secret")
+def test_reset_admin_password_skips_similarity_check_when_username_not_exists(
+    mock_reset_secret, mock_build_check
+):
+    """Test run() skips similarity check when username secret doesn't exist."""
+    mock_build_check.return_value = None
+    mock_reset_secret.return_value = True
+
+    reset_admin_password.run(argparse.Namespace())
+
+    call_kwargs = mock_reset_secret.call_args.kwargs
+    assert "check_similar" not in call_kwargs["check_requirements"]
+
+
+@pytest.mark.parametrize(
+    "username,password",
+    [
+        ("shadowman", "shadowman1"),
+        ("shadowman", "1shadowman"),
+        ("shadowman", "xshadowmanx"),
+        ("shadowman99", "shadowman1"),
+        ("shadowman", "shadowmen1"),
+        ("shadowman", "shadowXman"),
+        ("shadowman", "shadoman12"),
+        ("shadowman", "namwodahs1"),
+    ],
+)
+def test_reset_admin_password_rejects_similar_to_username(
+    mock_first_time_run, mocker, caplog, username, password
+):
+    """Test password is rejected when too similar to existing username."""
+    mock_first_time_run(reset_admin_password)
+
+    mocker.patch.object(
+        reset_admin_password.secrets.podman_utils,
+        "get_secret_value",
+        return_value=username,
+    )
+    mocker.patch.object(
+        reset_admin_password.secrets,
+        "prompt_secret",
+        return_value=password,
+    )
+
+    caplog.set_level(logging.ERROR)
+    result = reset_admin_password.run(argparse.Namespace())
+
+    assert not result
+    assert "too similar" in caplog.text.lower()
+
+
+@pytest.mark.parametrize(
+    "username,password",
+    [
+        ("shadowman", "Xk9#mP2$vL"),
+        ("shadowman", "shadow1234"),
+        ("shadowman", "shad123456"),
+        ("shadowman", "12shadow34"),
+    ],
+)
+def test_reset_admin_password_accepts_different_from_username(
+    mock_first_time_run, mocker, caplog, username, password
+):
+    """Test password is accepted when sufficiently different from username."""
+    mock_first_time_run(reset_admin_password)
+
+    mocker.patch.object(
+        reset_admin_password.secrets.podman_utils,
+        "get_secret_value",
+        return_value=username,
+    )
+    mocker.patch.object(
+        reset_admin_password.secrets,
+        "prompt_secret",
+        return_value=password,
+    )
+    mocker.patch.object(
+        reset_admin_password.podman_utils,
+        "set_secret",
+        return_value=True,
+    )
+
+    caplog.set_level(logging.DEBUG)
+    result = reset_admin_password.run(argparse.Namespace())
+
+    assert result

--- a/tests/commands/test_reset_admin_username.py
+++ b/tests/commands/test_reset_admin_username.py
@@ -115,10 +115,10 @@ def test_reset_admin_username_requires_confirmation_when_replacing(mocker, caplo
     )
 
     caplog.set_level(logging.ERROR)
-    expected_last_log_message = "The admin login username was not updated."
+    expected_log_message = "The admin login username was not updated."
 
     assert not reset_admin_username.run(argparse.Namespace())
-    assert expected_last_log_message == caplog.messages[0]
+    assert expected_log_message in caplog.messages
 
 
 def test_reset_admin_username_succeeds_with_confirmation(mocker, caplog):

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -316,3 +316,33 @@ def test_reset_username_confirms_before_replacing(mocker, caplog):
     assert result is True
     call_kwargs = mock_get_new_username.call_args.kwargs
     assert call_kwargs.get("must_confirm_replace_existing") is True
+
+
+@mock.patch.object(secrets.podman_utils, "get_secret_value")
+def test_build_similar_value_check_secret_exists(mock_get_secret_value, faker):
+    """Test build_similar_value_check returns SimilarValueCheck when secret exists."""
+    secret_name = faker.slug()
+    secret_value = faker.password()
+    display_name = faker.sentence()
+    mock_get_secret_value.return_value = secret_value
+
+    result = secrets.build_similar_value_check(secret_name, display_name)
+
+    assert result is not None
+    assert result.value == secret_value
+    assert result.name == display_name
+    assert result.max_similarity == 0.7
+    mock_get_secret_value.assert_called_once_with(secret_name)
+
+
+@mock.patch.object(secrets.podman_utils, "get_secret_value")
+def test_build_similar_value_check_secret_not_exists(mock_get_secret_value, faker):
+    """Test build_similar_value_check returns None when secret doesn't exist."""
+    secret_name = faker.slug()
+    display_name = faker.sentence()
+    mock_get_secret_value.return_value = None
+
+    result = secrets.build_similar_value_check(secret_name, display_name)
+
+    assert result is None
+    mock_get_secret_value.assert_called_once_with(secret_name)


### PR DESCRIPTION
**Summary**
This PR adds dynamic similarity validation between the admin username and password during their respective reset operations. Instead of checking against a hardcoded "admin" value, the system now fetches the actual stored secret and validates that the new value is not too similar to its counterpart.

**Changes**
_podman_utils: Add get_secret_value function (ea76ceb)_
1. New function to retrieve the actual value of an existing podman secret
2. Added redact_output parameter to run_command() to prevent sensitive values from appearing in logs

_secrets: Add build_similar_value_check helper (70ac752)_
1. Helper function that fetches a podman secret and wraps it in a SimilarValueCheck object
2. Returns None if the secret doesn't exist, allowing callers to skip the similarity check gracefully

_reset_admin_password: Add dynamic similarity check (4fc6ab8)_
1. Replaced hardcoded "admin" similarity check with dynamic username lookup
2. Now fetches the actual stored username secret for validation
3. Skips the similarity check if no username has been set yet

_reset_admin_username: Add similarity check (ebce464)_

1. Added password similarity validation when setting a new username
2. Ensures the username is not too similar to the current password
3. Skips the check if no password has been set yet

## Summary by Sourcery

Enforce dynamic similarity checks between the admin username and password when resetting credentials, and add secure podman secret retrieval utilities.

New Features:
- Add dynamic similarity validation so new admin passwords are checked against the current username and new admin usernames are checked against the current password.
- Introduce a helper to build similarity checks from existing podman secrets, skipping validation gracefully when the counterpart secret is missing.
- Add a podman utility to retrieve existing secret values while supporting redacted command output logging.

Enhancements:
- Allow username reset helpers to accept configurable check requirements and reuse the common secret validation logic.
- Extend the generic command runner to optionally redact stdout and stderr from logs for sensitive operations.

Tests:
- Add unit tests covering similarity-check behavior when resetting admin usernames and passwords, including accept and reject paths.
- Add tests for the new podman secret retrieval helper, including error handling, argument validation, and whitespace preservation.
- Add tests for building similarity checks from secrets, including the case where the underlying secret is absent.