### PR TITLE
fix(network): enable IPv6 support in Quadlet

### DIFF
--- a/src/quipucordsctl/templates/config/quipucords.network
+++ b/src/quipucordsctl/templates/config/quipucords.network
@@ -1,2 +1,2 @@
 [Network]
-
+IPv6=true


### PR DESCRIPTION
Adds IPv6=true to the Podman network Quadlet to allow containers to reach IPv6 targets. Without this setting, the container network only supports IPv4, causing "Network is unreachable" errors when scanning IPv6-only environments.

Related to JIRA: DISCOVERY-1245

## Summary by Sourcery

Bug Fixes:
- Allow containers on the quipucords Quadlet network to connect to IPv6 destinations instead of failing with "Network is unreachable" errors.