### PR TITLE
docs: group commands in `--help` to improve readability

### DIFF
--- a/src/quipucordsctl/argparse_utils.py
+++ b/src/quipucordsctl/argparse_utils.py
@@ -1,7 +1,87 @@
 """Helper functions to support argparse."""
 
 import argparse
+import enum
+import logging
+import types
 from gettext import gettext as _
+
+from quipucordsctl import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DisplayGroups(enum.Enum):
+    """Enum of possible display group names for argparse help text."""
+
+    MAIN = _("Main Commands")
+    CONFIG = _("Advanced Configuration Commands")
+    DIAGNOSTICS = _("Diagnostic Commands")
+    OTHER = _("Other Commands")
+
+
+def add_command(  # noqa: PLR0913
+    subparser: argparse._SubParsersAction,
+    command_module: types.ModuleType,
+    argparse_display_group: argparse._ArgumentGroup,
+    command_name: str,
+    help_text: str | None,
+    description: str | None,
+    epilog: str | None,
+) -> None:
+    """
+    Add a command to the parser and make it display under a specific group name.
+
+    This function enables us to change the display of commands to list under
+    different groupings in the help text while not actually affecting the functional
+    behavior of the parser and its arguments.
+
+    We use this helper function to encapsulate making direct changes to subparser
+    internals that are not exposed through normal Python APIs. We access some member
+    properties that are `_` "protected" which *could* be problematic in theory, but
+    in practice these properties and how they are used are very stable and have not
+    changed in any significant way for a long time.
+    """
+    usage = _("{prog} [OPTIONS...] {name} [COMMAND OPTIONS...]").format(
+        prog=settings.PROGRAM_NAME, name=command_name
+    )
+    command_parser = subparser.add_parser(
+        command_name,
+        help=help_text,
+        description=description,
+        epilog=epilog,
+        usage=usage,
+    )
+    if hasattr(command_module, "setup_parser"):
+        command_module.setup_parser(command_parser)
+
+    # Here we move the actual action object (the last one added) to our display group.
+    # The above call to subparser.add_parser *should always* append to _choices_actions.
+    # If future Python internals have changed unexpectedly, this will fail loudly and
+    # raise an exception to the top of the stack, ending execution.
+    try:
+        if subparser._choices_actions[-1].dest == command_name:
+            argparse_display_group._group_actions.append(subparser._choices_actions[-1])
+        else:
+            raise ValueError(
+                _(
+                    "subparser._choices_actions[-1].dest was %(value)s, "
+                    "but add_command expected %(command_name)s"
+                )
+                % {
+                    "value": repr(subparser._choices_actions[-1].dest),
+                    "command_name": repr(command_name),
+                }
+            )
+    except (AttributeError, IndexError, KeyError, ValueError) as e:
+        logger.exception(
+            _(
+                "Failed to add command '%(command_name)s' to argparse display group "
+                "due to an unexpected error: %(error)s"
+            ),
+            {"command_name": command_name, "error": str(e)},
+        )
+        raise
 
 
 def non_negative_integer(value: str) -> int:

--- a/src/quipucordsctl/commands/check.py
+++ b/src/quipucordsctl/commands/check.py
@@ -13,10 +13,15 @@ from enum import Enum
 from gettext import gettext as _
 from typing import Optional
 
-from quipucordsctl import settings
+from quipucordsctl import argparse_utils, settings
 from quipucordsctl.systemctl_utils import check_service_running
 
 logger = logging.getLogger(__name__)
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.DIAGNOSTICS
 
 
 class StatusType(Enum):

--- a/src/quipucordsctl/commands/export_logs.py
+++ b/src/quipucordsctl/commands/export_logs.py
@@ -12,10 +12,15 @@ from datetime import datetime
 from gettext import gettext as _
 from pathlib import Path
 
-from quipucordsctl import settings, shell_utils
+from quipucordsctl import argparse_utils, settings, shell_utils
 
 logger = logging.getLogger(__name__)
 BUFSIZE = 5 * 1024 * 1024  # 5 MB
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.DIAGNOSTICS
 
 
 class PreconditionsNotMetError(Exception):

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from gettext import gettext as _
 
 from quipucordsctl import (
+    argparse_utils,
     loginctl_utils,
     podman_utils,
     settings,
@@ -40,6 +41,11 @@ INSTALL_SUCCESS_LONG_MESSAGE = _(
 )
 
 logger = logging.getLogger(__name__)
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.MAIN
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_admin_password.py
+++ b/src/quipucordsctl/commands/reset_admin_password.py
@@ -10,7 +10,7 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +19,11 @@ USERNAME_SECRET_NAME = settings.QUIPUCORDS_SECRETS["username"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}SERVER_PASSWORD"
 MIN_LENGTH = 10
 BLOCKLIST = ["dscpassw0rd", "qpcpassw0rd"]
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_admin_username.py
+++ b/src/quipucordsctl/commands/reset_admin_username.py
@@ -9,13 +9,18 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 
 PODMAN_SECRET_NAME = settings.QUIPUCORDS_SECRETS["username"]
 PASSWORD_SECRET_NAME = settings.QUIPUCORDS_SECRETS["server"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}SERVER_USERNAME"
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_database_password.py
+++ b/src/quipucordsctl/commands/reset_database_password.py
@@ -10,13 +10,18 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 PODMAN_SECRET_NAME = settings.QUIPUCORDS_SECRETS["db"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}DBMS_PASSWORD"
 MIN_LENGTH = 16
 REQUIREMENTS = {"min_length": MIN_LENGTH}
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_encryption_secret.py
+++ b/src/quipucordsctl/commands/reset_encryption_secret.py
@@ -10,13 +10,18 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 PODMAN_SECRET_NAME = settings.QUIPUCORDS_SECRETS["encryption"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}ENCRYPTION_SECRET_KEY"
 MIN_LENGTH = 64
 REQUIREMENTS = {"min_length": MIN_LENGTH}
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_redis_password.py
+++ b/src/quipucordsctl/commands/reset_redis_password.py
@@ -10,13 +10,18 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 PODMAN_SECRET_NAME = settings.QUIPUCORDS_SECRETS["redis"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}REDIS_PASSWORD"
 MIN_LENGTH = 64
 REQUIREMENTS = {"min_length": MIN_LENGTH}
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/reset_session_secret.py
+++ b/src/quipucordsctl/commands/reset_session_secret.py
@@ -11,13 +11,18 @@ import logging
 import textwrap
 from gettext import gettext as _
 
-from quipucordsctl import podman_utils, secrets, settings
+from quipucordsctl import argparse_utils, podman_utils, secrets, settings
 
 logger = logging.getLogger(__name__)
 PODMAN_SECRET_NAME = settings.QUIPUCORDS_SECRETS["session"]
 ENV_VAR_NAME = f"{settings.ENV_VAR_PREFIX}SESSION_SECRET_KEY"
 MIN_LENGTH = 64
 REQUIREMENTS = {"min_length": MIN_LENGTH}
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/uninstall.py
+++ b/src/quipucordsctl/commands/uninstall.py
@@ -8,6 +8,7 @@ from gettext import gettext as _
 from pathlib import Path
 
 from quipucordsctl import (
+    argparse_utils,
     loginctl_utils,
     podman_utils,
     settings,
@@ -16,6 +17,11 @@ from quipucordsctl import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.MAIN
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/commands/upgrade.py
+++ b/src/quipucordsctl/commands/upgrade.py
@@ -11,6 +11,11 @@ from quipucordsctl.commands import install
 logger = logging.getLogger(__name__)
 
 
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.MAIN
+
+
 def get_help() -> str:
     """Get the help/docstring for this command."""
     return _("Upgrade the %(server_software_name)s server") % {

--- a/tests/test_argparse_utils.py
+++ b/tests/test_argparse_utils.py
@@ -1,6 +1,7 @@
 """Test the quipucordsctl.argparse_utils module."""
 
 import argparse
+from unittest import mock
 
 import pytest
 
@@ -18,3 +19,49 @@ def test_non_negative_integer_invalid(value):
     """Test non_negative_integer happy paths."""
     with pytest.raises(argparse.ArgumentTypeError):
         argparse_utils.non_negative_integer(value)
+
+
+def test_add_command(faker):
+    """Test add_command correctly adds to a specific action group for help display."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    parser.add_argument_group(faker.slug())  # extra to force checking multiple groups
+    middle_argument_group = parser.add_argument_group(faker.slug())
+    parser.add_argument_group(faker.slug())  # extra to force checking multiple groups
+
+    mock_command = mock.Mock()
+    command_name = faker.slug()
+    command_help = faker.sentence()
+    command_description = faker.sentence()
+    command_epilog = faker.sentence()
+
+    argparse_utils.add_command(
+        subparsers,
+        mock_command,
+        middle_argument_group,
+        command_name,
+        command_help,
+        command_description,
+        command_epilog,
+    )
+
+    argparse_group = next(
+        filter(
+            lambda _group: _group.title == middle_argument_group.title,
+            parser._action_groups,
+        )
+    )
+    action = next(
+        filter(
+            lambda _action: _action.dest == command_name,
+            argparse_group._group_actions,
+        )
+    )
+    # If action is found in the filtered action group, then it was added as expected.
+    # This is an implicit assertion by virtue of the "next"s not raising StopIteration.
+
+    mock_command.setup_parser.assert_called_once()
+    assert action.dest == command_name
+    assert action.help == command_help
+    assert subparsers.choices[command_name].description == command_description
+    assert subparsers.choices[command_name].epilog == command_epilog

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from quipucordsctl import cli
+from quipucordsctl import argparse_utils, cli
 
 
 def test_load_commands():
@@ -29,8 +29,27 @@ def test_create_parser_and_parse(faker):
     mock_command_doc = faker.sentence()
     mock_command = mock.Mock()
     mock_command.__doc__ = mock_command_doc
+    mock_command.get_display_group = mock.Mock(
+        return_value=argparse_utils.DisplayGroups.OTHER
+    )
 
     parser = cli.create_parser({mock_command_name: mock_command})
+
+    # Check that the mock_command was created under the "other" group.
+    argparse_group = next(
+        filter(
+            lambda _group: _group.title == argparse_utils.DisplayGroups.OTHER.value,
+            parser._action_groups,
+        )
+    )
+    action = next(
+        filter(
+            lambda _action: _action.dest == mock_command_name,
+            argparse_group._group_actions,
+        )
+    )
+    assert action is not None
+    # If action exists in the filtered group, then it was added correctly.
 
     # Simplest no-arg invocation.
     parsed_args = parser.parse_args([])


### PR DESCRIPTION
I believe this makes our CLI's default help text look more professional and usable as it adopts a visual display style used by more sophisticated and popular command line programs (like `systemctl` and `uv`).

How the default `--help` looks before this change:

```
usage: quipucordsctl [-h] [-v] [-y] [-q] [-c OVERRIDE_CONF_DIR]
                     {check,export_logs,install,reset_admin_password,reset_admin_username,reset_database_password,reset_encryption_secret,reset_redis_password,reset_session_secret,uninstall,upgrade}
                     ...

Configure and manage local Quipucords services.

positional arguments:
  {check,export_logs,install,reset_admin_password,reset_admin_username,reset_database_password,reset_encryption_secret,reset_redis_password,reset_session_secret,uninstall,upgrade}
    check               Check config files and directories
    export_logs         Export Quipucords logs
    install             Install the Quipucords server
    reset_admin_password
                        Reset the admin login password
    reset_admin_username
                        Reset the admin login username
    reset_database_password
                        Reset the database password
    reset_encryption_secret
                        Reset the encryption secret key
    reset_redis_password
                        Reset the Redis password
    reset_session_secret
                        Reset the session secret key
    uninstall           Uninstall the Quipucords server
    upgrade             Upgrade the Quipucords server

options:
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbose output
  -y, --yes             Automatically answer 'y' to all confirmation prompts
  -q, --quiet           Quiet output (overrides `-v`/`--verbose`)
  -c OVERRIDE_CONF_DIR, --override-conf-dir OVERRIDE_CONF_DIR
                        Override configuration directory
```

And after this change:

```
usage: quipucordsctl [OPTIONS...] COMMAND [COMMAND OPTIONS...]

Configure and manage local Quipucords services.

options:
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbose output
  -y, --yes             Automatically answer 'y' to all confirmation prompts
  -q, --quiet           Quiet output (overrides `-v`/`--verbose`)
  -c OVERRIDE_CONF_DIR, --override-conf-dir OVERRIDE_CONF_DIR
                        Override configuration directory

Main Commands:
  install               Install the Quipucords server
  uninstall             Uninstall the Quipucords server
  upgrade               Upgrade the Quipucords server

Advanced Configuration Commands:
  reset_admin_password  Reset the admin login password
  reset_admin_username  Reset the admin login username
  reset_database_password
                        Reset the database password
  reset_encryption_secret
                        Reset the encryption secret key
  reset_redis_password  Reset the Redis password
  reset_session_secret  Reset the session secret key

Diagnostic Commands:
  check                 Check config files and directories
  export_logs           Export Quipucords logs
```

## Summary by Sourcery

Improve the CLI help experience by grouping commands into categorized sections and centralizing command registration logic.

New Features:
- Introduce display groups for CLI subcommands so help output is organized into main, configuration, diagnostic, and other command sections.

Enhancements:
- Add a shared helper for registering subcommands that assigns them to display groups without changing their functional behavior.
- Update the CLI parser usage text and subparser configuration to produce clearer, more user-friendly help output.

Tests:
- Extend CLI parser tests to cover commands that specify a display group for help grouping behavior.

## Summary by Sourcery

Organize quipucordsctl CLI subcommands into display groups to produce clearer, categorized help output without changing command behavior.

New Features:
- Introduce display groups for CLI subcommands so help output is organized into main, configuration, diagnostics, and other sections.

Enhancements:
- Add a shared helper for registering subcommands that assigns commands to display groups and customizes their usage strings while preserving argparse behavior.

Tests:
- Extend CLI parser tests to cover commands that specify a display group and ensure help grouping behavior remains stable.