### PR TITLE
Attempt to pull images during install command 

### DIFF
--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -32,9 +32,8 @@ from quipucordsctl.systemdunitparser import SystemdUnitParser
 INSTALL_SUCCESS_LONG_MESSAGE = _(
     textwrap.dedent(
         """
-        Installation completed successfully. Please run the following commands to start the %(server_software_name)s server:
+        Installation completed successfully. Please run the following command to start the %(server_software_name)s server:
 
-            podman login registry.redhat.io
             systemctl --user restart %(server_software_package)s-app
         """  # noqa: E501
     ).strip()
@@ -363,6 +362,9 @@ def run(args: argparse.Namespace) -> bool:
         systemctl_reload()
     except subprocess.CalledProcessError:
         logger.error(_("systemctl reload failed unexpectedly. Please check logs."))
+        return False
+
+    if not podman_utils.ensure_images():
         return False
 
     if not loginctl_utils.enable_linger(args.linger):


### PR DESCRIPTION
Add image verification and download to the install command. If required container images are missing, prompt the user to download them and handle registry login automatically.

**Changes**
- Add image detection functions to podman_utils.py
- Add registry login functions with secure password handling (stdin)
- Add ensure_images() orchestration function
- Integrate into install command
- Update success message (remove manual login instruction)

**Behavior**
- Images present → no prompts, install proceeds
- Images missing → prompt to download, handle login if needed
- -y flag → auto-download
- -q flag → exit silently if missing
- Offline → works if images are pre-loaded

**Testing**
Manual testing on Fedora:

- [x] All images present - No download prompt, straight to success
- [x]  Images missing, user confirms - Shows missing list, prompts, pulls successfully
- [x]  Images missing, user declines - Shows offline installation instructions
- [x]  Not logged in, login succeeds - Prompts for credentials, logs in, pulls
- [x]  Login fails (wrong credentials) - Shows error with manual login instructions
- [x] Pull fails (invalid image) - Shows troubleshooting tips (credentials/subscription/network)
- [x]  -y flag - Skips confirmation, auto-downloads
- [x]  -q flag - No output, exits with non-zero code
- [x]  -y -q together - -y wins, attempts download
- [x]  Offline install (pre-loaded images) - No network required, no prompts
- [x]  Upgrade (new image tag) - Detects new tag as missing even if old tag exists

**Pending**
- [x] RHEL8
- [x] RHEL9
- [x] RHEL10