### PR TITLE
fix: improve systemctl check, add linger arg to upgrade, check output directory permissions, rearrange help groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: uv sync
 
       - name: Run Test
-        run: make ${{ matrix.type }} -k
+        run: make ${{ matrix.type }} TEST_TIMEOUT=1.0 TEST_SESSION_TIMEOUT=10.0 -k
 
       - name: Report coverage
         if: ${{ success() && contains(matrix.type, 'test-coverage') }}

--- a/src/quipucordsctl/argparse_utils.py
+++ b/src/quipucordsctl/argparse_utils.py
@@ -15,8 +15,8 @@ class DisplayGroups(enum.Enum):
     """Enum of possible display group names for argparse help text."""
 
     MAIN = _("Main Commands")
-    CONFIG = _("Advanced Configuration Commands")
     DIAGNOSTICS = _("Diagnostic Commands")
+    CONFIG = _("Advanced Configuration Commands")
     OTHER = _("Other Commands")
 
 

--- a/src/quipucordsctl/cli.py
+++ b/src/quipucordsctl/cli.py
@@ -114,11 +114,11 @@ def create_parser(commands: dict[str, ModuleType]) -> argparse.ArgumentParser:
         argparse_utils.DisplayGroups.MAIN: parser.add_argument_group(
             argparse_utils.DisplayGroups.MAIN.value
         ),
-        argparse_utils.DisplayGroups.CONFIG: parser.add_argument_group(
-            argparse_utils.DisplayGroups.CONFIG.value
-        ),
         argparse_utils.DisplayGroups.DIAGNOSTICS: parser.add_argument_group(
             argparse_utils.DisplayGroups.DIAGNOSTICS.value
+        ),
+        argparse_utils.DisplayGroups.CONFIG: parser.add_argument_group(
+            argparse_utils.DisplayGroups.CONFIG.value
         ),
         argparse_utils.DisplayGroups.OTHER: parser.add_argument_group(
             argparse_utils.DisplayGroups.OTHER.value

--- a/src/quipucordsctl/commands/export_logs.py
+++ b/src/quipucordsctl/commands/export_logs.py
@@ -67,13 +67,14 @@ def check_preconditions(dest: Path) -> bool:
     """Check if path provided by user is a directory where we can create a new file."""
     if not dest.is_dir():
         logger.error(
-            _("Must be a directory: %(path)s"), {"path": dest.resolve().as_posix()}
+            _("Output path %(path)s must be a directory."),
+            {"path": dest.resolve().as_posix()},
         )
         return False
 
-    if not os.access(dest, os.R_OK | os.W_OK):
+    if not os.access(dest, os.R_OK | os.W_OK | os.X_OK):
         logger.error(
-            _("Directory %(path)s must be readable and writable"),
+            _("Output directory %(path)s must be readable, writable, and executable."),
             {"path": dest.resolve().as_posix()},
         )
         return False

--- a/src/quipucordsctl/commands/upgrade.py
+++ b/src/quipucordsctl/commands/upgrade.py
@@ -66,6 +66,14 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
         )
         % {"default": settings.DEFAULT_PODMAN_PULL_TIMEOUT},
     )
+    parser.add_argument(
+        "--linger",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help=_(
+            "Automatically enable lingering for the current user (default: --linger)",
+        ),
+    )
 
 
 def pull_latest_images(timeout: int | None = None) -> bool:

--- a/src/quipucordsctl/commands/upgrade.py
+++ b/src/quipucordsctl/commands/upgrade.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def get_display_group() -> argparse_utils.DisplayGroups:
     """Get the group identifier for displaying this command in CLI help text."""
-    return argparse_utils.DisplayGroups.MAIN
+    return argparse_utils.DisplayGroups.CONFIG
 
 
 def get_help() -> str:

--- a/src/quipucordsctl/podman_utils.py
+++ b/src/quipucordsctl/podman_utils.py
@@ -495,7 +495,8 @@ def _pull_missing_images(missing_images: set[str]) -> bool:
 
     Returns True if all pulls succeed, False otherwise.
     """
-    logger.debug(_("Pulling container images..."))
+    if not settings.runtime.quiet:
+        print(_("Pulling container images. This may take a few minutes."))
 
     for image in sorted(missing_images):
         logger.info(_("Pulling image: %(image)s"), {"image": image})

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -62,7 +62,7 @@ SYSTEMD_SERVICE_FILENAMES = (
 # System commands commonly run
 SYSTEMCTL_USER_RESET_FAILED_CMD = ["systemctl", "--user", "reset-failed"]
 SYSTEMCTL_USER_DAEMON_RELOAD_CMD = ["systemctl", "--user", "daemon-reload"]
-SYSTEMCTL_USER_IS_SYSTEM_RUNNING_CMD = ["systemctl", "--user", "is-system-running"]
+SYSTEMCTL_USER_IS_SYSTEM_RUNNING_CMD = ["systemctl", "--user", "show-environment"]
 SYSTEMCTL_USER_LIST_QUIPUCORDS_APP = [
     "systemctl",
     "-q",

--- a/tests/commands/test_export_logs.py
+++ b/tests/commands/test_export_logs.py
@@ -76,19 +76,20 @@ def test_run_output_is_not_dir(tmp_path: pathlib.Path, caplog):
     mock_args.output = output
 
     assert export_logs.run(mock_args) is False
-    assert "Must be a directory" in caplog.text
+    assert "must be a directory" in caplog.text
 
 
-def test_run_output_is_not_writable(tmp_path: pathlib.Path, caplog):
-    """Test the run command - output is not writable."""
+@pytest.mark.parametrize("mode", [0o000, 0o100, 0o200, 0o300, 0o400, 0o500, 0o600])
+def test_run_output_lacks_expected_modes(mode, tmp_path: pathlib.Path, caplog):
+    """Test export_logs checks required permissions/modes of output directory."""
     caplog.set_level(logging.ERROR)
     output = tmp_path / "new-dir"
-    output.mkdir(mode=0o444)
+    output.mkdir(mode=mode)
     mock_args = mock.Mock()
     mock_args.output = output
 
     assert export_logs.run(mock_args) is False
-    assert "must be readable and writable" in caplog.text
+    assert "must be readable, writable, and executable" in caplog.text
 
 
 def test_run_no_exported_files(tmp_path: pathlib.Path, caplog):

--- a/tests/commands/test_reset_admin_username.py
+++ b/tests/commands/test_reset_admin_username.py
@@ -113,6 +113,11 @@ def test_reset_admin_username_requires_confirmation_when_replacing(mocker, caplo
         "confirm",
         return_value=False,
     )
+    mocker.patch.object(
+        reset_admin_username.secrets,
+        "build_similar_value_check",
+        return_value=False,
+    )
 
     caplog.set_level(logging.ERROR)
     expected_log_message = "The admin login username was not updated."
@@ -128,6 +133,11 @@ def test_reset_admin_username_succeeds_with_confirmation(mocker, caplog):
         reset_admin_username.podman_utils,
         "secret_exists",
         return_value=True,
+    )
+    mocker.patch.object(
+        reset_admin_username.secrets,
+        "build_similar_value_check",
+        return_value=None,
     )
     mocker.patch.object(
         reset_admin_username.secrets.shell_utils,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,17 @@ import pathlib
 import pkgutil
 from collections.abc import Generator
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def forbid_shell_utils_subprocess(monkeypatch):
+    """Forbid subprocess.Popen invocation in tests."""
+    mock_subprocess = MagicMock()
+    monkeypatch.setattr("quipucordsctl.shell_utils.subprocess.Popen", mock_subprocess)
+    mock_subprocess.side_effect = Exception("This should never be called in a test!!!")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR contains another assortment of fixes and improvements identified during recent manual testing exercises.

Relates to JIRA: DISCOVERY-1246

## Summary by Sourcery

Tighten CLI behavior and diagnostics by improving log export directory validation, adjusting help display groups, refining systemd integration, and adding a linger option to the upgrade command.

Bug Fixes:
- Ensure export_logs validates that the output directory is executable in addition to being readable and writable, and improve related error messages and tests.
- Update the systemd user status check to use `systemctl --user show-environment` instead of `is-system-running` for better compatibility.

Enhancements:
- Move the upgrade command into the advanced configuration help group and reorder CLI help groups for clearer categorization.
- Add a --linger/--no-linger flag to the upgrade command to control automatic lingering for the current user.

Tests:
- Expand export_logs tests to cover multiple non-writable/non-executable directory mode combinations and align expectations with updated error messages.