### PR TITLE
test: enable pytest-timeout to help spot bad tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PYTHON		= $(shell uv run which python 2>/dev/null || which python)
-TEST_OPTS := -ra
+TEST_TIMEOUT ?= "0.5"
+TEST_SESSION_TIMEOUT ?= "5.0"
+TEST_OPTS := -ra --timeout=$(TEST_TIMEOUT) --session-timeout=$(TEST_SESSION_TIMEOUT)
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,12 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "pytest-mock>=3.14.1",
+    "pytest-timeout>=2.4.0",
     "ruff>=0.12.2",
 ]
+
+[tool.pytest]
+addopts = ["--timeout=0.5", "--session-timeout=5.0"]
 
 [tool.ruff]
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ dev = [
     "ruff>=0.12.2",
 ]
 
-[tool.pytest]
-addopts = ["--timeout=0.5", "--session-timeout=5.0"]
-
 [tool.ruff]
 lint.select = [
     "C90", # mccabe complexity

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "quipucordsctl"
 version = "2.4.2"
 source = { editable = "." }
@@ -171,6 +183,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -184,6 +197,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.12.2" },
 ]
 


### PR DESCRIPTION
Background: I recently saw a new test was suspiciously slow, but more interestingly it was _inconsistently slow_. I discovered it was actually trying to execute `podman pull` images with faker-generated names like `registry.redhat.io/three-image-son:latest`, but that unexpected behavior wasn't clearly _visible_ because the test in question was specifically trying to mimic a similar "external" podman failure. We missed a mock and actually invoked a real podman error. Whoops!

I also ran into a _different_ issue earlier where a test was hanging forever because we missed a mock around one of the `input`s, and the test was waiting for an input it would never receive.

Adding these timeouts to our unit test runs, all of which _should always_ be blazing fast, should give us early warnings about problems in our unit tests like these missed mocks. Reverting my earlier unit test fixes and rerunning the test suite with `pytest-timeout` enabled _immediately_ drew my attention to the lines that were misbehaving in those tests.

Here's an example of how "slow" tests will trigger `pytest-timeout` and fail the overall run:

```
>       time.sleep(1)
E       Failed: Timeout (>0.25s) from pytest-timeout.

tests/test_podman_utils.py:19: Failed
=========================== short test summary info ============================
FAILED tests/test_podman_utils.py::test_ensure_cgroups_v2_happy_path - Failed: Timeout (>0.25s) from pytest-timeout.
======================== 1 failed, 357 passed in 0.69s =========================
make: *** [Makefile:34: test] Error 1
```

## Summary by Sourcery

Enable timeouts in the test suite to surface slow or hanging unit tests during development.

Build:
- Add pytest-timeout as a development dependency and update dependency lockfile.

Tests:
- Configure pytest to enforce per-test and per-session timeouts for the unit test suite.