### PR TITLE
chore: update license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 70"]
+requires = ["setuptools >= 77"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -25,9 +25,7 @@ requires-python = "<3.14,>=3.12"
 authors = [
     {name = "Quipucords Dev Team", email = "quipucords@redhat.com"},
 ]
-# license should preferably follow identifiers listed at the SPDX Open Source License Registry.
-# https://spdx.org/licenses/
-license = {text = "GPL-3.0-or-later"}
+license = "GPL-3.0-or-later"
 readme = "README.md"
 dependencies = []
 


### PR DESCRIPTION
`license` used to be defined as a table with a file or a text key, but that format has been deprecated by PEP-639, accepted in January 2025. Current setuptools issued following warning when building a package:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

  ********************************************************************************
  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

  By 2027-Feb-18, you need to update your project and remove deprecated calls
  or your builds will no longer be supported.

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************

  !!
```