### PR TITLE
fix(export_logs): disable journalctl "this looks like binary" heuristic

### DIFF
--- a/src/quipucordsctl/commands/export_logs.py
+++ b/src/quipucordsctl/commands/export_logs.py
@@ -107,7 +107,7 @@ def export_container_logs(dest: Path):
             _("Exporting logs from %(service_name)s"), {"service_name": service}
         )
         fname = Path(service).stem
-        command = ["journalctl", f"--user-unit={service}"]
+        command = ["journalctl", "--all", f"--user-unit={service}"]
         try:
             dest_filename = (dest / "j.log").with_stem(fname)
             with dest_filename.open("w") as fh:

--- a/tests/commands/test_export_logs.py
+++ b/tests/commands/test_export_logs.py
@@ -119,7 +119,7 @@ def test_export_container_logs_happy_path(tmp_path: pathlib.Path, mock_shell_uti
     for service in settings.SYSTEMD_SERVICE_FILENAMES:
         expected_calls.append(
             mock.call(
-                ["journalctl", f"--user-unit={service}"],
+                ["journalctl", "--all", f"--user-unit={service}"],
                 wait_timeout=mock.ANY,
                 bufsize=mock.ANY,
                 stdout=mock.ANY,
@@ -160,7 +160,7 @@ def test_export_container_logs_file_open_error(
         for service in other_services:
             expected_calls.append(
                 mock.call(
-                    ["journalctl", f"--user-unit={service}"],
+                    ["journalctl", "--all", f"--user-unit={service}"],
                     wait_timeout=mock.ANY,
                     bufsize=mock.ANY,
                     stdout=mock.ANY,
@@ -193,7 +193,7 @@ def test_export_container_logs_journalctl_failure(
     for service in settings.SYSTEMD_SERVICE_FILENAMES:
         expected_calls.append(
             mock.call(
-                ["journalctl", f"--user-unit={service}"],
+                ["journalctl", "--all", f"--user-unit={service}"],
                 wait_timeout=mock.ANY,
                 bufsize=mock.ANY,
                 stdout=mock.ANY,


### PR DESCRIPTION
On RHEL8, raw `journalctl` may result in lines like:

    Feb 18 07:23:36 localhost quipucords-celery-worker[9735]: [2.4K blob data]

journalctl has a heuristic to detect if data might be a binary, and substitutes it with above placeholder if it is - probably to not pollute terminal output. Unfortunately, on ancient systemd versions that heuristic seems to match for Windows-like newline characters, which for whatever reason are common in ansible output.

`--all` flag tells journalctl to give what it has, even if it might be a binary data.

## Summary by Sourcery

Ensure exported container logs include full journalctl output, even when entries are treated as binary data.

Bug Fixes:
- Force journalctl to emit full log lines by adding the --all flag when exporting systemd user-unit logs to avoid placeholder blob entries on some systems.

Tests:
- Update export_logs command tests to expect the journalctl --all flag for all relevant service log exports.