### PR TITLE
fix(install): check systemd user session first

### DIFF
--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -338,9 +338,9 @@ def systemctl_reload():
 def run(args: argparse.Namespace) -> bool:
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
+    systemctl_utils.ensure_systemd_user_session()
     podman_utils.ensure_podman_socket()
     podman_utils.ensure_cgroups_v2()
-    systemctl_utils.ensure_systemd_user_session()
 
     if not reset_secrets(args):
         return False


### PR DESCRIPTION
`ensure_podman_socket()` will try to enable and get the status of user session-scoped podman socket service. It doesn't make sense to run `systemctl --user` commands and check for working user session only once they succeeded.

To be specific, without this change, we get:
```
$ sudo -i
# sudo useradd podmanuser
# su - podmanuser
$ quipucordsctl install
ERROR: Failed to connect to bus: No such file or directory
ERROR: Subprocess with arguments ['systemctl', '--user', 'enable', '--now', 'podman.socket'] failed with exit code 1
ERROR: The 'podman.socket' service failed to start. Please check logs and ensure that Podman is correctly installed.

ERROR: Command '['systemctl', '--user', 'enable', '--now', 'podman.socket']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/quipucordsctl/cli.py", line 234, in run
    if not commands[args.command].run(args):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/quipucordsctl/commands/install.py", line 341, in run
    podman_utils.ensure_podman_socket()
  File "/usr/lib/python3.12/site-packages/quipucordsctl/podman_utils.py", line 85, in ensure_podman_socket
    raise e
  File "/usr/lib/python3.12/site-packages/quipucordsctl/podman_utils.py", line 74, in ensure_podman_socket
    shell_utils.run_command(
  File "/usr/lib/python3.12/site-packages/quipucordsctl/shell_utils.py", line 169, in run_command
    raise subprocess.CalledProcessError(
subprocess.CalledProcessError: Command '['systemctl', '--user', 'enable', '--now', 'podman.socket']' returned non-zero exit status 1.
```

That check was added in #37, after we already moved from podman Python bindings to raw podman commands (#32). I don't see any relevant changes to `podman_utils`, `systemctl_utils` or install command since then, so at this point I'm unsure if that ever worked as intended.

## Summary by Sourcery

Bug Fixes:
- Prevent install failures by checking for a valid systemd user session before attempting to enable the user-scoped podman.socket service.