### PR TITLE
build: update quipucordsctl to version 2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ quipucordsctl = "quipucordsctl.__main__:main"
 
 [project]
 name = "quipucordsctl"
-version = "2.4.2"
+version = "2.5.0"
 description = "Utility for installing and managing a local quipucords server."
 requires-python = "<3.14,>=3.12"
 authors = [

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -1,8 +1,8 @@
 ###############################################################
 %global product_name_lower quipucords
 %global product_name_title Quipucords
-%global server_image quay.io/quipucords/quipucords:2.4
-%global ui_image quay.io/quipucords/quipucords-ui:2.4
+%global server_image quay.io/quipucords/quipucords:2.5
+%global ui_image quay.io/quipucords/quipucords-ui:2.5
 ###############################################################
 
 %global version_ctl 2.5.0
@@ -177,7 +177,8 @@ sed -i 's#^Image=.*#Image=%{ui_image}#g' %{buildroot}/%{_datadir}/%{name}/config
 %endif
 
 %changelog
-* Fri Feb 13 2026 Brad Smith <brasmith@redhat.com> - 0:2.5.0-1
+* Tue Mar 10 2026 Brad Smith <brasmith@redhat.com> - 0:2.5.0-1
+- First public release
 - provide and obsolete %{old_installer_package}
 
 * Wed Sep 17 2025 Alberto Bellotti <abellott@redhat.com> - 0:2.1.0-1

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "quipucordsctl"
-version = "2.4.2"
+version = "2.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-1287

## Summary by Sourcery

Update quipucordsctl package metadata for the 2.5.0 release and record it as the first public release.

Build:
- Update RPM spec changelog entry to mark 2.5.0-1 as the first public release with correct release date.

Chores:
- Bump Python project version from 2.4.2 to 2.5.0 in pyproject metadata.