### PR TITLE
fix: reduce terminal noise

### DIFF
--- a/src/quipucordsctl/podman_utils.py
+++ b/src/quipucordsctl/podman_utils.py
@@ -432,8 +432,6 @@ def login_to_registry(registry: str) -> bool:
     ):
         return False
 
-    print(_("Logging in to '%(registry)s'...") % {"registry": registry})
-
     username = input(_("Username: "))
     if not username.strip():
         logger.error(_("Username cannot be empty."))

--- a/tests/test_podman_utils.py
+++ b/tests/test_podman_utils.py
@@ -707,7 +707,7 @@ def test_check_registry_login_not_logged_in(mock_run_command, caplog):
 @mock.patch.object(podman_utils.shell_utils, "run_command")
 @mock.patch.object(podman_utils.shell_utils, "confirm")
 def test_login_to_registry_success(  # noqa: PLR0913
-    mock_confirm, mock_run_command, mock_input, mock_getpass, faker, caplog, capsys
+    mock_confirm, mock_run_command, mock_input, mock_getpass, faker, caplog
 ):
     """Test login_to_registry returns True on successful login."""
     caplog.set_level(logging.INFO)
@@ -729,7 +729,6 @@ def test_login_to_registry_success(  # noqa: PLR0913
         redact_output=False,
     )
     assert f"Successfully logged in to registry '{registry}'." in caplog.messages[-1]
-    assert "Logging in to" in capsys.readouterr().out
 
 
 @mock.patch.object(podman_utils.shell_utils, "run_command")


### PR DESCRIPTION
Do not print message that does not add value. It's clear from context which registry we are attempting to log in to.

Relates to JIRA: DISCOVERY-1324

## Summary by Sourcery

Remove unnecessary registry login status message to reduce terminal output noise during podman registry authentication.

Bug Fixes:
- Stop printing a redundant 'Logging in to' message when logging into a registry.

Tests:
- Update registry login success test to no longer expect the removed console message and drop unused capsys fixture.