### PR TITLE
chore: Remove upper Python version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ quipucordsctl = "quipucordsctl.__main__:main"
 name = "quipucordsctl"
 version = "2.5.0"
 description = "Utility for installing and managing a local quipucords server."
-requires-python = "<3.14,>=3.12"
+requires-python = ">=3.12"
 authors = [
     {name = "Quipucords Dev Team", email = "quipucords@redhat.com"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12, <3.14"
+requires-python = ">=3.12"
 
 [[package]]
 name = "babel"


### PR DESCRIPTION
Fedora now defaults to Python 3.14, which makes installing quipucordsctl through pipx unnecessarily difficult.

Removal of upper version cap does not mean recommendation, endorsement, or official support.