### PR TITLE
build: update Fedora 42 to 43 in Packit build targets list

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,6 +20,8 @@ jobs:
       # and also build on Fedora as an early preview of future releases.
       - fedora-42-x86_64
       - fedora-42-aarch64
+      - fedora-43-x86_64
+      - fedora-43-aarch64
 
   - job: copr_build
     trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,8 +18,6 @@ jobs:
       - rhel-10-x86_64
       - rhel-10-aarch64
       # and also build on Fedora as an early preview of future releases.
-      - fedora-42-x86_64
-      - fedora-42-aarch64
       - fedora-43-x86_64
       - fedora-43-aarch64
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Switch Packit build targets from Fedora 42 (x86_64, aarch64) to Fedora 43 (x86_64, aarch64).