### PR TITLE
Adding support for server start command

### DIFF
--- a/docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1
@@ -56,7 +56,7 @@ This manual page describes the commands and options for the \fBQUIPUCORDSCTL_VAR
 The \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP command manages the QUIPUCORDSCTL_VAR_PROJECT deployment lifecycle. Within that workflow, \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP performs the following major tasks:
 .INDENT 0.0
 .IP \(bu 2
-Installing QUIPUCORDSCTL_VAR_PROJECT:
+Installing and starting QUIPUCORDSCTL_VAR_PROJECT:
 .sp
 \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME install\fP
 .IP \(bu 2
@@ -83,15 +83,16 @@ The following sections describe these commands and their options in more detail.
 .SH INSTALLATION
 .SS Installing QUIPUCORDSCTL_VAR_PROJECT
 .sp
-To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT.
+To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT and starts the QUIPUCORDSCTL_VAR_PROJECT application service.
 .sp
 \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME install\fP
+.INDENT 0.0
+.TP
+.B \fB\-\-start, \-\-no\-start\fP
+Automatically start the server after installation (default: \-\-start)
+.UNINDENT
 .sp
-After installation, start the QUIPUCORDSCTL_VAR_PROJECT application service:
-.sp
-\fBsystemctl \-\-user restart quipucords\-app\fP
-.sp
-After a few seconds, access QUIPUCORDSCTL_VAR_PROJECT at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
+After the installation, access QUIPUCORDSCTL_VAR_PROJECT at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
 .SS Uninstalling QUIPUCORDSCTL_VAR_PROJECT
 .sp
 To completely remove QUIPUCORDSCTL_VAR_PROJECT and all its data, use the \fBuninstall\fP command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
@@ -194,13 +195,12 @@ Load override values from this custom configuration directory. Use this to defin
 .SH EXAMPLES
 .INDENT 0.0
 .IP \(bu 2
-Installing QUIPUCORDSCTL_VAR_PROJECT:
+Installing and starting QUIPUCORDSCTL_VAR_PROJECT:
 .INDENT 2.0
 .INDENT 3.5
 .sp
 .EX
 $ QUIPUCORDSCTL_VAR_PROGRAM_NAME install
-$ systemctl \-\-user restart quipucords\-app
 .EE
 .UNINDENT
 .UNINDENT
@@ -231,6 +231,26 @@ Installing with maximum verbosity:
 .sp
 .EX
 $ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-vvv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing but not starting QUIPUCORDSCTL_VAR_PROJECT:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME install \-\-no\-start
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Starting QUIPUCORDSCTL_VAR_PROJECT if not automatically started:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME start
 .EE
 .UNINDENT
 .UNINDENT

--- a/docs/_build/man-quipucordsctl.rst
+++ b/docs/_build/man-quipucordsctl.rst
@@ -27,7 +27,7 @@ Usage
 
 The ``quipucordsctl`` command manages the Quipucords deployment lifecycle. Within that workflow, ``quipucordsctl`` performs the following major tasks:
 
-* Installing Quipucords:
+* Installing and starting Quipucords:
 
   ``quipucordsctl install``
 
@@ -57,15 +57,14 @@ Installation
 Installing Quipucords
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To install Quipucords and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running Quipucords.
+To install Quipucords and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, prepares the environment for running Quipucords and starts the Quipucords application service.
 
 ``quipucordsctl install``
 
-After installation, start the Quipucords application service:
+``--start, --no-start``
+    Automatically start the server after installation (default: --start)
 
-``systemctl --user restart quipucords-app``
-
-After a few seconds, access Quipucords at https://localhost:9443
+After the installation, access Quipucords at https://localhost:9443
 
 Uninstalling Quipucords
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -181,10 +180,9 @@ The following options are available for every quipucordsctl command.
 Examples
 --------
 
-* Installing Quipucords::
+* Installing and starting Quipucords::
 
     $ quipucordsctl install
-    $ systemctl --user restart quipucords-app
 
 * Verifying services are running::
 
@@ -197,6 +195,14 @@ Examples
 * Installing with maximum verbosity::
 
     $ quipucordsctl -vvv install
+
+* Installing but not starting Quipucords::
+
+    $ quipucordsctl install --no-start
+
+* Starting Quipucords if not automatically started::
+
+    $ quipucordsctl start
 
 * Checking installation status::
 

--- a/docs/_build/quipucordsctl.1
+++ b/docs/_build/quipucordsctl.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "quipucordsctl" "1" "June 05, 2026" "" "quipucordsctl"
+.TH "quipucordsctl" "1" "June 09, 2026" "" "quipucordsctl"
 .SH NAME
 quipucordsctl \- Deploy and manage Quipucords in Podman containers
 .SH SYNOPSIS
@@ -56,7 +56,7 @@ This manual page describes the commands and options for the \fBquipucordsctl\fP 
 The \fBquipucordsctl\fP command manages the Quipucords deployment lifecycle. Within that workflow, \fBquipucordsctl\fP performs the following major tasks:
 .INDENT 0.0
 .IP \(bu 2
-Installing Quipucords:
+Installing and starting Quipucords:
 .sp
 \fBquipucordsctl install\fP
 .IP \(bu 2
@@ -83,15 +83,16 @@ The following sections describe these commands and their options in more detail.
 .SH INSTALLATION
 .SS Installing Quipucords
 .sp
-To install Quipucords and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running Quipucords.
+To install Quipucords and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, prepares the environment for running Quipucords and starts the Quipucords application service.
 .sp
 \fBquipucordsctl install\fP
+.INDENT 0.0
+.TP
+.B \fB\-\-start, \-\-no\-start\fP
+Automatically start the server after installation (default: \-\-start)
+.UNINDENT
 .sp
-After installation, start the Quipucords application service:
-.sp
-\fBsystemctl \-\-user restart quipucords\-app\fP
-.sp
-After a few seconds, access Quipucords at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
+After the installation, access Quipucords at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
 .SS Uninstalling Quipucords
 .sp
 To completely remove Quipucords and all its data, use the \fBuninstall\fP command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
@@ -194,13 +195,12 @@ Load override values from this custom configuration directory. Use this to defin
 .SH EXAMPLES
 .INDENT 0.0
 .IP \(bu 2
-Installing Quipucords:
+Installing and starting Quipucords:
 .INDENT 2.0
 .INDENT 3.5
 .sp
 .EX
 $ quipucordsctl install
-$ systemctl \-\-user restart quipucords\-app
 .EE
 .UNINDENT
 .UNINDENT
@@ -231,6 +231,26 @@ Installing with maximum verbosity:
 .sp
 .EX
 $ quipucordsctl \-vvv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing but not starting Quipucords:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl install \-\-no\-start
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Starting Quipucords if not automatically started:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl start
 .EE
 .UNINDENT
 .UNINDENT

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -27,7 +27,7 @@ Usage
 
 The ``QUIPUCORDSCTL_VAR_PROGRAM_NAME`` command manages the QUIPUCORDSCTL_VAR_PROJECT deployment lifecycle. Within that workflow, ``QUIPUCORDSCTL_VAR_PROGRAM_NAME`` performs the following major tasks:
 
-* Installing QUIPUCORDSCTL_VAR_PROJECT:
+* Installing and starting QUIPUCORDSCTL_VAR_PROJECT:
 
   ``QUIPUCORDSCTL_VAR_PROGRAM_NAME install``
 
@@ -57,15 +57,14 @@ Installation
 Installing QUIPUCORDSCTL_VAR_PROJECT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT.
+To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT and starts the QUIPUCORDSCTL_VAR_PROJECT application service.
 
 ``QUIPUCORDSCTL_VAR_PROGRAM_NAME install``
 
-After installation, start the QUIPUCORDSCTL_VAR_PROJECT application service:
+``--start, --no-start``
+    Automatically start the server after installation (default: --start)
 
-``systemctl --user restart quipucords-app``
-
-After a few seconds, access QUIPUCORDSCTL_VAR_PROJECT at https://localhost:9443
+After the installation, access QUIPUCORDSCTL_VAR_PROJECT at https://localhost:9443
 
 Uninstalling QUIPUCORDSCTL_VAR_PROJECT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -181,10 +180,9 @@ The following options are available for every QUIPUCORDSCTL_VAR_PROGRAM_NAME com
 Examples
 --------
 
-* Installing QUIPUCORDSCTL_VAR_PROJECT::
+* Installing and starting QUIPUCORDSCTL_VAR_PROJECT::
 
     $ QUIPUCORDSCTL_VAR_PROGRAM_NAME install
-    $ systemctl --user restart quipucords-app
 
 * Verifying services are running::
 
@@ -197,6 +195,14 @@ Examples
 * Installing with maximum verbosity::
 
     $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -vvv install
+
+* Installing but not starting QUIPUCORDSCTL_VAR_PROJECT::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME install --no-start
+
+* Starting QUIPUCORDSCTL_VAR_PROJECT if not automatically started::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME start
 
 * Checking installation status::
 

--- a/scripts/translations.py
+++ b/scripts/translations.py
@@ -16,13 +16,15 @@ https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 
 import argparse
 import pathlib
+import re
 import subprocess
 import sys
 import sysconfig
 
 DOMAIN = "messages"
 PYBABEL_BIN = pathlib.Path(sys.prefix) / "bin" / "pybabel"
-SOURCE_CODE_DIR = pathlib.Path(__file__).parent.parent / "src" / "quipucordsctl"
+SOURCE_PATH = pathlib.Path("src/quipucordsctl")
+SOURCE_CODE_DIR = pathlib.Path(__file__).parent.parent / SOURCE_PATH
 LOCALES_DIR = SOURCE_CODE_DIR / "locale"
 PYTHON_STDLIB_FILES = ["argparse.py"]
 LOCALES = ["en"]
@@ -30,7 +32,7 @@ LOCALES = ["en"]
 
 def get_code_paths() -> list:
     """Get a list of paths that contain gettext-wrapped strings to localize."""
-    code_paths = [SOURCE_CODE_DIR]
+    code_paths = [SOURCE_PATH]
     stdlib_path = pathlib.Path(sysconfig.get_paths()["stdlib"])
     for stdlib_file_name in PYTHON_STDLIB_FILES:
         stdlib_file_path = stdlib_path / stdlib_file_name
@@ -39,22 +41,42 @@ def get_code_paths() -> list:
     return code_paths
 
 
+def normalize_stdlib_location_comments(pot_file: pathlib.Path) -> None:
+    """Normalize stdlib location comments to remove environment-specific paths.
+
+    pybabel writes the full path to stdlib files (e.g. argparse.py) in location
+    comments, which varies across Python installations and environments. Replace the
+    path prefix with '...' so the comment is stable across contributors.
+
+    Before: #: ../../../../.pyenv/versions/3.12.5/lib/python3.12/argparse.py:228
+    After:  #: .../python3.12/argparse.py:228
+    """
+    stdlib_file_pattern = re.compile(
+        r"(#: ).*/(python\d+\.\d+/" + "|".join(PYTHON_STDLIB_FILES) + r":\d+)"
+    )
+    text = pot_file.read_text(encoding="utf-8")
+    normalized = stdlib_file_pattern.sub(r"\1.../\2", text)
+    pot_file.write_text(normalized, encoding="utf-8")
+
+
 def translations_extract(pybabel_bin):
     """Extract gettext-wrapped strings to messages.pot template file."""
     paths: list[str] = get_code_paths()
+    pot_file = LOCALES_DIR / f"{DOMAIN}.pot"
     try:
         subprocess.check_call(  # noqa: S603
             [
                 pybabel_bin,
                 "extract",
                 "-o",
-                str(LOCALES_DIR / f"{DOMAIN}.pot"),
+                str(pot_file),
                 *(str(path) for path in paths),
             ],
         )
     except subprocess.CalledProcessError as e:
         print(f"Error invoking pybabel extract: {e}")
         sys.exit(1)
+    normalize_stdlib_location_comments(pot_file)
 
 
 def translations_update(pybabel_bin):

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -35,13 +35,13 @@ INSTALL_SUCCESS_MESSAGE = _(
 INSTALL_SUCCESS_NO_START_MESSAGE = _(
     textwrap.dedent(
         """
-        Installation of %(server_software_name)s completed successfully.
-        Please run the following command to start the server:
+        Installation completed successfully. Please run the following command to start the %(server_software_name)s server:
 
             %(program_name)s start
-        """
+        """  # noqa: E501
     ).strip()
 )
+
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +347,7 @@ def systemctl_reload():
     shell_utils.run_command(settings.SYSTEMCTL_USER_DAEMON_RELOAD_CMD)
 
 
-def _resolve_override_conf_dir(
+def resolve_override_conf_dir(
     override_conf_dir: str | None,
 ) -> pathlib.Path | None:
     """Resolve and validate the override configuration directory argument."""
@@ -366,7 +366,7 @@ def _resolve_override_conf_dir(
     return None
 
 
-def _start_and_print_success(args: argparse.Namespace) -> bool:
+def start_server(args: argparse.Namespace) -> bool:
     """Start the server and print the appropriate success message."""
     if args.start:
         if not systemctl_utils.start_service():
@@ -397,7 +397,7 @@ def run(args: argparse.Namespace) -> bool:
     if not reset_secrets(args):
         return False
 
-    override_conf_dir_path = _resolve_override_conf_dir(args.override_conf_dir)
+    override_conf_dir_path = resolve_override_conf_dir(args.override_conf_dir)
     write_config_files(override_conf_dir_path)
     try:
         systemctl_reload()
@@ -411,4 +411,4 @@ def run(args: argparse.Namespace) -> bool:
     if not loginctl_utils.enable_linger(args.linger):
         return False
 
-    return _start_and_print_success(args)
+    return start_server(args)

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -29,14 +29,14 @@ from quipucordsctl.commands import (
 )
 from quipucordsctl.systemdunitparser import SystemdUnitParser
 
-INSTALL_SUCCESS_MESSAGE = _(
+INSTALL_SUCCESS_START_MESSAGE = _(
     "Installation of %(server_software_name)s completed successfully."
 )
 INSTALL_SUCCESS_NO_START_MESSAGE = _(
     textwrap.dedent(
         """
         Installation of %(server_software_name)s completed successfully.
-        Run the following command to start the server:
+        Please run the following command to start the server:
 
             %(program_name)s start
         """
@@ -53,7 +53,7 @@ def get_display_group() -> argparse_utils.DisplayGroups:
 
 def get_help() -> str:
     """Get the help/docstring for this command."""
-    return _("Install the %(server_software_name)s server") % {
+    return _("Install and start the %(server_software_name)s server") % {
         "server_software_name": settings.SERVER_SOFTWARE_NAME
     }
 
@@ -373,7 +373,7 @@ def _start_and_print_success(args: argparse.Namespace) -> bool:
             return False
         if not args.quiet:
             print(
-                INSTALL_SUCCESS_MESSAGE
+                INSTALL_SUCCESS_START_MESSAGE
                 % {"server_software_name": settings.SERVER_SOFTWARE_NAME},
             )
     elif not args.quiet:
@@ -388,7 +388,7 @@ def _start_and_print_success(args: argparse.Namespace) -> bool:
 
 
 def run(args: argparse.Namespace) -> bool:
-    """Install the server, ensuring requirements are met."""
+    """Install and start the server, ensuring requirements are met."""
     logger.debug("Starting install command")
     systemctl_utils.ensure_systemd_user_session()
     podman_utils.ensure_podman_socket()

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -29,13 +29,17 @@ from quipucordsctl.commands import (
 )
 from quipucordsctl.systemdunitparser import SystemdUnitParser
 
-INSTALL_SUCCESS_LONG_MESSAGE = _(
+INSTALL_SUCCESS_MESSAGE = _(
+    "Installation of %(server_software_name)s completed successfully."
+)
+INSTALL_SUCCESS_NO_START_MESSAGE = _(
     textwrap.dedent(
         """
-        Installation completed successfully. Please run the following command to start the %(server_software_name)s server:
+        Installation of %(server_software_name)s completed successfully.
+        Run the following command to start the server:
 
-            systemctl --user restart %(server_software_package)s-app
-        """  # noqa: E501
+            %(program_name)s start
+        """
     ).strip()
 )
 
@@ -87,6 +91,14 @@ def setup_parser(parser: argparse.ArgumentParser) -> None:
         action=argparse.BooleanOptionalAction,
         help=_(
             "Automatically enable lingering for the current user (default: --linger)",
+        ),
+    )
+    parser.add_argument(
+        "--start",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help=_(
+            "Automatically start the server after installation (default: --start)",
         ),
     )
 
@@ -335,6 +347,46 @@ def systemctl_reload():
     shell_utils.run_command(settings.SYSTEMCTL_USER_DAEMON_RELOAD_CMD)
 
 
+def _resolve_override_conf_dir(
+    override_conf_dir: str | None,
+) -> pathlib.Path | None:
+    """Resolve and validate the override configuration directory argument."""
+    if not override_conf_dir:
+        return None
+    path = pathlib.Path(override_conf_dir)
+    if path.is_dir():
+        return path
+    logger.warning(
+        _(
+            "The specified override configuration directory "
+            "('%(override_conf_dir)s') does not exist."
+        ),
+        {"override_conf_dir": override_conf_dir},
+    )
+    return None
+
+
+def _start_and_print_success(args: argparse.Namespace) -> bool:
+    """Start the server and print the appropriate success message."""
+    if args.start:
+        if not systemctl_utils.start_service():
+            return False
+        if not args.quiet:
+            print(
+                INSTALL_SUCCESS_MESSAGE
+                % {"server_software_name": settings.SERVER_SOFTWARE_NAME},
+            )
+    elif not args.quiet:
+        print(
+            INSTALL_SUCCESS_NO_START_MESSAGE
+            % {
+                "server_software_name": settings.SERVER_SOFTWARE_NAME,
+                "program_name": settings.PROGRAM_NAME,
+            },
+        )
+    return True
+
+
 def run(args: argparse.Namespace) -> bool:
     """Install the server, ensuring requirements are met."""
     logger.debug("Starting install command")
@@ -345,18 +397,7 @@ def run(args: argparse.Namespace) -> bool:
     if not reset_secrets(args):
         return False
 
-    override_conf_dir_path = None
-    if args.override_conf_dir:
-        if pathlib.Path(args.override_conf_dir).is_dir():
-            override_conf_dir_path = pathlib.Path(args.override_conf_dir)
-        else:
-            logger.warning(
-                _(
-                    "The specified override configuration directory "
-                    "('%(override_conf_dir)s') does not exist."
-                ),
-                {"override_conf_dir": args.override_conf_dir},
-            )
+    override_conf_dir_path = _resolve_override_conf_dir(args.override_conf_dir)
     write_config_files(override_conf_dir_path)
     try:
         systemctl_reload()
@@ -370,12 +411,4 @@ def run(args: argparse.Namespace) -> bool:
     if not loginctl_utils.enable_linger(args.linger):
         return False
 
-    if not args.quiet:
-        print(
-            INSTALL_SUCCESS_LONG_MESSAGE
-            % {
-                "server_software_name": settings.SERVER_SOFTWARE_NAME,
-                "server_software_package": settings.SERVER_SOFTWARE_PACKAGE,
-            },
-        )
-    return True
+    return _start_and_print_success(args)

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -30,7 +30,8 @@ from quipucordsctl.commands import (
 from quipucordsctl.systemdunitparser import SystemdUnitParser
 
 INSTALL_SUCCESS_MESSAGE = _(
-    "Installation of %(server_software_name)s completed successfully."
+    "Installation of %(server_software_name)s completed"
+    " and the server started successfully."
 )
 INSTALL_SUCCESS_NO_START_MESSAGE = _(
     textwrap.dedent(

--- a/src/quipucordsctl/commands/install.py
+++ b/src/quipucordsctl/commands/install.py
@@ -29,7 +29,7 @@ from quipucordsctl.commands import (
 )
 from quipucordsctl.systemdunitparser import SystemdUnitParser
 
-INSTALL_SUCCESS_START_MESSAGE = _(
+INSTALL_SUCCESS_MESSAGE = _(
     "Installation of %(server_software_name)s completed successfully."
 )
 INSTALL_SUCCESS_NO_START_MESSAGE = _(
@@ -373,7 +373,7 @@ def _start_and_print_success(args: argparse.Namespace) -> bool:
             return False
         if not args.quiet:
             print(
-                INSTALL_SUCCESS_START_MESSAGE
+                INSTALL_SUCCESS_MESSAGE
                 % {"server_software_name": settings.SERVER_SOFTWARE_NAME},
             )
     elif not args.quiet:

--- a/src/quipucordsctl/commands/start.py
+++ b/src/quipucordsctl/commands/start.py
@@ -1,0 +1,56 @@
+"""Start the server."""
+
+import argparse
+import textwrap
+from gettext import gettext as _
+
+from quipucordsctl import argparse_utils, podman_utils, settings, systemctl_utils
+
+_START_SUCCESS_MESSAGE = _("%(server_software_name)s server started successfully.")
+
+
+def get_display_group() -> argparse_utils.DisplayGroups:
+    """Get the group identifier for displaying this command in CLI help text."""
+    return argparse_utils.DisplayGroups.MAIN
+
+
+def get_help() -> str:
+    """Get the help/docstring for this command."""
+    return _("Start the %(server_software_name)s server") % {
+        "server_software_name": settings.SERVER_SOFTWARE_NAME
+    }
+
+
+def get_description() -> str:
+    """Get the longer description of this command."""
+    return _(
+        textwrap.dedent(
+            """
+            Start the %(server_software_name)s server.
+            Before starting, this command checks for and pulls any missing container
+            images. It then starts the server and waits for it to become active.
+            If the server fails to start, a non-zero exit code is returned along with
+            diagnostic information and guidance on how to investigate the failure.
+            """
+        )
+    ) % {"server_software_name": settings.SERVER_SOFTWARE_NAME}
+
+
+def run(args: argparse.Namespace) -> bool:
+    """Start the server, ensuring requirements are met and images are present."""
+    systemctl_utils.ensure_systemd_user_session()
+    podman_utils.ensure_podman_socket()
+    podman_utils.ensure_cgroups_v2()
+
+    if not podman_utils.ensure_images():
+        return False
+
+    if not systemctl_utils.start_service():
+        return False
+
+    if not args.quiet:
+        print(
+            _START_SUCCESS_MESSAGE
+            % {"server_software_name": settings.SERVER_SOFTWARE_NAME}
+        )
+    return True

--- a/src/quipucordsctl/commands/start.py
+++ b/src/quipucordsctl/commands/start.py
@@ -6,10 +6,15 @@ from gettext import gettext as _
 
 from quipucordsctl import argparse_utils, podman_utils, settings, systemctl_utils
 
-_START_SUCCESS_MESSAGE = _("%(server_software_name)s server started successfully.")
-_NOT_INSTALLED_MESSAGE = _(
-    "%(server_software_name)s is not installed. "
-    "Please install it first by running '%(program_name)s install'."
+START_SUCCESS_MESSAGE = _("%(server_software_name)s server started successfully.")
+SERVER_NOT_INSTALLED_MESSAGE = _(
+    textwrap.dedent(
+        """
+        %(server_software_name)s is not installed. Please install it first by running the following command:
+
+            %(program_name)s install
+        """  # noqa: E501 line-too-long
+    ).strip()
 )
 
 
@@ -44,7 +49,7 @@ def run(args: argparse.Namespace) -> bool:
     """Start the server, ensuring requirements are met and images are present."""
     if not systemctl_utils.is_service_installed():
         print(
-            _NOT_INSTALLED_MESSAGE
+            SERVER_NOT_INSTALLED_MESSAGE
             % {
                 "server_software_name": settings.SERVER_SOFTWARE_NAME,
                 "program_name": settings.PROGRAM_NAME,
@@ -64,7 +69,7 @@ def run(args: argparse.Namespace) -> bool:
 
     if not args.quiet:
         print(
-            _START_SUCCESS_MESSAGE
+            START_SUCCESS_MESSAGE
             % {"server_software_name": settings.SERVER_SOFTWARE_NAME}
         )
     return True

--- a/src/quipucordsctl/commands/start.py
+++ b/src/quipucordsctl/commands/start.py
@@ -7,6 +7,10 @@ from gettext import gettext as _
 from quipucordsctl import argparse_utils, podman_utils, settings, systemctl_utils
 
 _START_SUCCESS_MESSAGE = _("%(server_software_name)s server started successfully.")
+_NOT_INSTALLED_MESSAGE = _(
+    "%(server_software_name)s is not installed. "
+    "Please install it first by running '%(program_name)s install'."
+)
 
 
 def get_display_group() -> argparse_utils.DisplayGroups:
@@ -38,6 +42,16 @@ def get_description() -> str:
 
 def run(args: argparse.Namespace) -> bool:
     """Start the server, ensuring requirements are met and images are present."""
+    if not systemctl_utils.is_service_installed():
+        print(
+            _NOT_INSTALLED_MESSAGE
+            % {
+                "server_software_name": settings.SERVER_SOFTWARE_NAME,
+                "program_name": settings.PROGRAM_NAME,
+            }
+        )
+        return False
+
     systemctl_utils.ensure_systemd_user_session()
     podman_utils.ensure_podman_socket()
     podman_utils.ensure_cgroups_v2()

--- a/src/quipucordsctl/locale/messages.pot
+++ b/src/quipucordsctl/locale/messages.pot
@@ -1,481 +1,832 @@
 # Translations template for PROJECT.
-# Copyright (C) 2025 ORGANIZATION
+# Copyright (C) 2026 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-30 20:38-0300\n"
+"POT-Creation-Date: 2026-05-28 21:13-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/argparse_utils.py:9
+#: src/quipucordsctl/argparse_utils.py:17
+msgid "Main Commands"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:18
+msgid "Diagnostic Commands"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:19
+msgid "Advanced Configuration Commands"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:20
+msgid "Other Commands"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:45
+#, python-brace-format
+msgid "{prog} [OPTIONS...] {name} [COMMAND OPTIONS...]"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:68
+#, python-format
+msgid ""
+"subparser._choices_actions[-1].dest was %(value)r, but add_command "
+"expected %(command_name)r"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:79
+#, python-format
+msgid ""
+"Failed to add command '%(command_name)s' to argparse display group due to"
+" an unexpected error: %(error)s"
+msgstr ""
+
+#: src/quipucordsctl/argparse_utils.py:89
 #, python-format
 msgid "invalid non-negative integer value: '%(value)s'"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:35
+#: src/quipucordsctl/cli.py:67
+#, python-format
+msgid "%(prog)s [OPTIONS...] COMMAND [COMMAND OPTIONS...]"
+msgstr ""
+
+#: src/quipucordsctl/cli.py:68
+#, python-format
+msgid "Configure and manage local %(server_software_name)s services."
+msgstr ""
+
+#: src/quipucordsctl/cli.py:77
 msgid "Increase verbose output"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:43
+#: src/quipucordsctl/cli.py:85
 msgid "Automatically answer 'y' to all confirmation prompts"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:51
+#: src/quipucordsctl/cli.py:93
 msgid "Quiet output (overrides `-v`/`--verbose`)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:58
+#: src/quipucordsctl/cli.py:100
+msgid "Control the use of color in output"
+msgstr ""
+
+#: src/quipucordsctl/cli.py:106
 msgid "Override configuration directory"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:129
+#: src/quipucordsctl/cli.py:204
+msgid "Cannot install log handler due to existing handler."
+msgstr ""
+
+#: src/quipucordsctl/cli.py:240
 msgid "Exiting due to keyboard interrupt."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/cli.py:133
+#: src/quipucordsctl/cli.py:244
 msgid "Input closed unexpectedly."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:49
+#: src/quipucordsctl/loginctl_utils.py:30
+#: src/quipucordsctl/loginctl_utils.py:57
+#, python-format
+msgid "'Linger' is enabled for user '%(username)s'"
+msgstr ""
+
+#: src/quipucordsctl/loginctl_utils.py:37
+#, python-format
+msgid ""
+"loginctl failed unexpectedly. Unable to check 'Linger' property for user "
+"'%(username)s'. Please check logs."
+msgstr ""
+
+#: src/quipucordsctl/loginctl_utils.py:50
+#, python-format
+msgid "'Linger' will not be checked or enabled for user '%(username)s'."
+msgstr ""
+
+#: src/quipucordsctl/loginctl_utils.py:62
+#, python-format
+msgid "Enabling 'Linger' for user '%(username)s'"
+msgstr ""
+
+#: src/quipucordsctl/loginctl_utils.py:71
+#, python-format
+msgid ""
+"loginctl failed unexpectedly. Failed to enable 'Linger' for user "
+"'%(username)s'. Please check logs."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:51
 msgid "Ensuring Podman socket is available."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:59
+#: src/quipucordsctl/podman_utils.py:61
 msgid ""
 "Podman command failed unexpectedly. Please install Podman and run `podman"
 " machine start` before using this command."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:66
+#: src/quipucordsctl/podman_utils.py:68
 msgid ""
 "Podman machine is not running. Please install Podman and run `podman "
 "machine start` before using this command."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:79
+#: src/quipucordsctl/podman_utils.py:81
 msgid ""
 "The 'podman.socket' service failed to start. Please check logs and ensure"
 " that Podman is correctly installed."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:89
+#: src/quipucordsctl/podman_utils.py:91
 #, python-format
 msgid ""
 "Podman socket does not exist at expected path (%(socket_path)s). Please "
 "check logs and ensure that Podman is correctly installed.socket_path"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:121
+#: src/quipucordsctl/podman_utils.py:123
 msgid "Ensuring cgroups v2 is enabled."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:126
+#: src/quipucordsctl/podman_utils.py:128
 msgid "Podman info command failed unexpectedly."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:133
+#: src/quipucordsctl/podman_utils.py:135
 msgid "Podman info failed to return valid JSON."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:142
+#: src/quipucordsctl/podman_utils.py:144
 msgid "cgroups v2 is required but not available."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:166
+#: src/quipucordsctl/podman_utils.py:168
 #, python-format
 msgid "Skipping the %(unit_file)s container file due to missing section headers."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:190
+#: src/quipucordsctl/podman_utils.py:192
 #, python-format
 msgid "Unexpected type '%(type)s' for %(name)s with value %(value)r."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:194
+#: src/quipucordsctl/podman_utils.py:196
 #, python-format
 msgid "Missing value for %(name)s."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:199
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:218
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:265
+#: src/quipucordsctl/podman_utils.py:201 src/quipucordsctl/podman_utils.py:266
 msgid "podman secret name"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:205
+#: src/quipucordsctl/podman_utils.py:207
 #, python-format
 msgid "Podman secret '%(secret_name)s' exists."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:210
+#: src/quipucordsctl/podman_utils.py:212
 #, python-format
 msgid "Podman secret '%(secret_name)s' does not exist."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:224
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:232
+#: src/quipucordsctl/podman_utils.py:225 src/quipucordsctl/podman_utils.py:233
 #, python-format
 msgid "Podman secret '%(secret_name)s' already exists before setting a new value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:251
+#: src/quipucordsctl/podman_utils.py:252
 #, python-format
 msgid "Podman secret '%(secret_name)s' was set."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:257
+#: src/quipucordsctl/podman_utils.py:258
 #, python-format
 msgid "Podman failed to set secret '%(secret_name)s'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:271
+#: src/quipucordsctl/podman_utils.py:272
 #, python-format
 msgid "Podman secret '%(secret_name)s' was removed."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:276
+#: src/quipucordsctl/podman_utils.py:277
 #, python-format
 msgid "Podman failed to remove secret '%(secret_name)s'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:284
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:301
-msgid "podman image ID"
+#: src/quipucordsctl/podman_utils.py:285 src/quipucordsctl/podman_utils.py:302
+msgid "container image ID"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:290
+#: src/quipucordsctl/podman_utils.py:291
 #, python-format
-msgid "Podman image '%(image_id)s' was removed."
+msgid "Removed container image '%(image_id)s'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:294
+#: src/quipucordsctl/podman_utils.py:295
 #, python-format
-msgid "Podman failed to remove image '%(image_id)s'."
+msgid "Failed to remove container image '%(image_id)s'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/podman_utils.py:309
+#: src/quipucordsctl/podman_utils.py:310
 #, python-format
 msgid "Failed to pull image %(image)s."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:34
-msgid ""
-"You should only manually reset this secret if you understand how it is "
-"used, and you are addressing a specific issue. We strongly recommend "
-"using the automatically generated value for this secret instead of "
-"manually entering one."
+#: src/quipucordsctl/podman_utils.py:338
+#, python-format
+msgid "Failed to retrieve podman secret '%(secret_name)s'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:40
+#: src/quipucordsctl/podman_utils.py:346
+msgid "podman image name"
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:352
+#, python-format
+msgid "Container image '%(image_name)s' exists locally."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:357
+#, python-format
+msgid "Container image '%(image_name)s' does not exist locally."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:379
+#, python-format
+msgid "Missing %(count)d of %(total)d required images."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:383
+msgid "All required images are present locally."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:395 src/quipucordsctl/podman_utils.py:424
+msgid "registry"
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:406
+#, python-format
+msgid "Valid credentials already exist for registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:411
+#, python-format
+msgid "Not logged in to registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:431
+#, python-format
+msgid "Log in to registry '%(registry)s'?"
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:435
+msgid "Username: "
+msgstr ""
+
+#: src/quipucordsctl/commands/reset_admin_username.py:64
+#: src/quipucordsctl/podman_utils.py:437
+msgid "Username cannot be empty."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:439
+msgid "Password: "
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:441
+msgid "Password cannot be empty."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:453
+#, python-format
+msgid "Successfully logged in to registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:459
+#, python-format
+msgid "Failed to log in to registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:469
+#, python-format
+msgid "Required container image '%(image)s' is missing."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:480
+#, python-format
+msgid "Valid credentials do not exist for registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:485
+#, python-format
+msgid "Could not log in to registry '%(registry)s'."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:497
+msgid "Pulling container images. This may take a few minutes."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:500
+#, python-format
+msgid "Pulling image: %(image)s"
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:517
+msgid "All required container images are present."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:523
+#, python-format
+msgid "Should %(program)s pull missing images from the container registry?"
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:527
+msgid "Installation cannot proceed without all required container images."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:529
+msgid "For disconnected installation, see the online documentation."
+msgstr ""
+
+#: src/quipucordsctl/podman_utils.py:537
+msgid "All required images have been pulled successfully."
+msgstr ""
+
+#: src/quipucordsctl/secrets.py:34
+#, python-format
+msgid ""
+"%(program_name)s generates cryptographically strong random passwords by "
+"default. You should manually reset the this secret only if your "
+"environment specifically requires a custom value."
+msgstr ""
+
+#: src/quipucordsctl/secrets.py:39
 msgid "Are you sure you want to manually reset this secret?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:44
+#: src/quipucordsctl/secrets.py:43
 #, python-format
 msgid ""
 "This secret already exists with a value. Resetting this secret to a new "
-"value may result in data loss if you have already installed and run "
-"%(SERVER_SOFTWARE_NAME)s on this system."
+"value may break %(SERVER_SOFTWARE_NAME)s or result in data loss if you "
+"have already installed and run %(SERVER_SOFTWARE_NAME)s on this system."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:52
+#: src/quipucordsctl/secrets.py:52
 msgid "Are you sure you want to replace the existing secret?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:54
+#: src/quipucordsctl/secrets.py:54
 msgid "Enter new secret value: "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:55
+#: src/quipucordsctl/secrets.py:55
 msgid "Confirm new secret value: "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:56
+#: src/quipucordsctl/secrets.py:56
 msgid "Your inputs do not match."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:57
+#: src/quipucordsctl/secrets.py:57
 msgid "This secret was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:60
+#: src/quipucordsctl/secrets.py:60
 #, python-format
 msgid "The value for this secret must be at least %(min_length)s characters long."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:63
+#: src/quipucordsctl/secrets.py:63
 msgid "The value for this secret must contain a number."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:66
+#: src/quipucordsctl/secrets.py:66
 msgid "The value for this secret must contain a letter."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:69
+#: src/quipucordsctl/secrets.py:69
 msgid "The value for this secret cannot by entirely numeric."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:72
+#: src/quipucordsctl/secrets.py:72
 msgid "The value you provided cannot be used because it is blocked."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:75
+#: src/quipucordsctl/secrets.py:75
 msgid "The value you provided is too similar to another secret's value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:77
+#: src/quipucordsctl/secrets.py:77
 msgid "The value cannot be empty."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:79
+#: src/quipucordsctl/secrets.py:79
 msgid "This value is required but cannot be prompted in quiet mode."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:81
+#: src/quipucordsctl/secrets.py:81
 msgid "The secret was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:82
+#: src/quipucordsctl/secrets.py:82
 msgid "The secret was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/secrets.py:302
+#: src/quipucordsctl/secrets.py:350
 #, python-format
 msgid ""
 "New value for podman secret '%(PODMAN_SECRET_NAME)s' was randomly "
 "generated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:20
+#: src/quipucordsctl/shell_utils.py:20
 #, python-format
 msgid "Environment variable '%(name)s' found."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:23
+#: src/quipucordsctl/shell_utils.py:23
 #, python-format
 msgid "Environment variable '%(name)s' not found."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:36
+#: src/quipucordsctl/shell_utils.py:36
 msgid "Do you want to continue?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:38
+#: src/quipucordsctl/shell_utils.py:38
 #, python-format
 msgid "%(question)s [y/n] "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:40
+#: src/quipucordsctl/shell_utils.py:40
 msgid "y"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:42
+#: src/quipucordsctl/shell_utils.py:42
 msgid "n"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:43
+#: src/quipucordsctl/shell_utils.py:43
 msgid "Please answer with 'y' or 'n'."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:83
+#: src/quipucordsctl/shell_utils.py:88
 #, python-format
 msgid "Command arguments must be strings. Got: %r"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:84
+#: src/quipucordsctl/shell_utils.py:89
 #, python-format
 msgid "Invoking subprocess: %s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:88
+#: src/quipucordsctl/shell_utils.py:93
 #, python-format
 msgid "Command has %(wait_timeout)s seconds timeout."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:109
+#: src/quipucordsctl/shell_utils.py:132
 #, python-format
 msgid ""
 "Subprocess with arguments %(command)s timed out after %(wait_timeout)s "
 "seconds."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:117
+#: src/quipucordsctl/shell_utils.py:140
 #, python-format
 msgid "Subprocess with arguments %(command)s failed due to unexpected error."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/shell_utils.py:133
+#: src/quipucordsctl/shell_utils.py:150 src/quipucordsctl/shell_utils.py:156
+msgid "[REDACTED]"
+msgstr ""
+
+#: src/quipucordsctl/shell_utils.py:164
 #, python-format
 msgid "Subprocess with arguments %(command)s failed with exit code %(exit_code)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/systemctl_utils.py:14
+#: src/quipucordsctl/systemctl_utils.py:21
+msgid "Ensuring systemd user session is enabled."
+msgstr ""
+
+#: src/quipucordsctl/systemctl_utils.py:25
+#, python-format
+msgid ""
+"XDG_RUNTIME_DIR variable is not set. User systemd session will not work "
+"properly and you will encounter issues when trying to start "
+"%(server_software_name)s. If this is a remote machine, please SSH "
+"directly as the current user (instead of using sudo or su)."
+msgstr ""
+
+#: src/quipucordsctl/systemctl_utils.py:41
+#, python-format
+msgid ""
+"systemctl self-check reported problems. System is probably misconfigured "
+"and you are likely to encounter issues when trying to start "
+"%(server_software_name)s."
+msgstr ""
+
+#: src/quipucordsctl/systemctl_utils.py:52
 #, python-format
 msgid "Stopping the %(server_software_name)s server."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/systemctl_utils.py:26
+#: src/quipucordsctl/systemctl_utils.py:64
 #, python-format
 msgid "Could not stop the %(server_software_name)s server."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/systemctl_utils.py:30
+#: src/quipucordsctl/systemctl_utils.py:68
 #, python-format
 msgid "Error stopping %(server_software_name)s: %(error)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:105
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/systemctl_utils.py:42
+#: src/quipucordsctl/commands/uninstall.py:148
+#: src/quipucordsctl/systemctl_utils.py:80
 msgid "Reloading the systemctl daemon."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/systemctl_utils.py:51
+#: src/quipucordsctl/systemctl_utils.py:97
 #, python-format
 msgid "Checking if %(server_software_name)s service is active"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:43
+#: src/quipucordsctl/systemctl_utils.py:117
 #, python-format
 msgid ""
-"Check that all necessary files and directories exist for running "
-"%(server_software_name)s."
+"\n"
+"        %(server_software_name)s failed to start. Check the journal for "
+"errors:\n"
+"\n"
+"            journalctl --user -u %(server_software_package)s-app\n"
+"\n"
+"        You may also run '%(program_name)s check' for a system health "
+"check.\n"
+"        "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:127
+#: src/quipucordsctl/systemctl_utils.py:149
+#, python-format
+msgid "Starting the %(server_software_name)s server."
+msgstr ""
+
+#: src/quipucordsctl/systemctl_utils.py:161
+#, python-format
+msgid "Failed to issue start command for %(server_software_name)s."
+msgstr ""
+
+#: src/quipucordsctl/systemctl_utils.py:171
+#, python-format
+msgid "%(server_software_name)s server is active."
+msgstr ""
+
+#: src/quipucordsctl/commands/check.py:48
+msgid "Check config files and directories"
+msgstr ""
+
+#: src/quipucordsctl/commands/check.py:145
 #, python-format
 msgid "%(path)s: OK: %(perms)s %(owner)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:137
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:157
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:182
+#: src/quipucordsctl/commands/check.py:155
+#: src/quipucordsctl/commands/check.py:175
+#: src/quipucordsctl/commands/check.py:200
 #, python-format
 msgid "Unexpected error reporting status of %(path)s: %(error)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:140
+#: src/quipucordsctl/commands/check.py:158
 #, python-format
 msgid "%(path)s: OK"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:148
+#: src/quipucordsctl/commands/check.py:166
 #, python-format
 msgid "%(path)s: ERROR: Incorrect permission(s): %(perms)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:160
+#: src/quipucordsctl/commands/check.py:178
 #, python-format
 msgid "%(path)s: ERROR: Incorrect permissions"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:169
+#: src/quipucordsctl/commands/check.py:187
 #, python-format
 msgid "%(path)s: ERROR: Not owned by you (incorrect ownership): %(uid)s %(owner)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:186
+#: src/quipucordsctl/commands/check.py:204
 #, python-format
 msgid "%(path)s: ERROR: Not owned by you (incorrect ownership)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:200
+#: src/quipucordsctl/commands/check.py:218
 #, python-format
 msgid "%(path)s: ERROR: Missing"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:203
+#: src/quipucordsctl/commands/check.py:221
 #, python-format
 msgid "%(path)s: Missing, will be created during server startup"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:207
+#: src/quipucordsctl/commands/check.py:225
 #, python-format
 msgid "%(path)s: ERROR: Unknown status"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:306
+#: src/quipucordsctl/commands/check.py:324
 #, python-format
 msgid "Checking %(server_software_name)s setup and configurations."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:321
+#: src/quipucordsctl/commands/check.py:339
 msgid "All checks passed successfully."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/check.py:324
+#: src/quipucordsctl/commands/check.py:342
 #, python-format
 msgid "Found %(error_count)d issues."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:41
+#: src/quipucordsctl/commands/export_logs.py:32
 #, python-format
-msgid "Install the %(server_software_name)s server."
+msgid "Export %(server_software_name)s logs"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:76
+#: src/quipucordsctl/commands/export_logs.py:60
+msgid ""
+"Path to directory where logs archive will be created (default: current "
+"working directory)"
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:70
+#, python-format
+msgid "Output path %(path)s must be a directory."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:77
+#, python-format
+msgid "Output directory %(path)s must be readable, writable, and executable."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:91
+#, python-format
+msgid "Failed to copy some files from %(filepath)s. Logs may not be complete."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:107
+#, python-format
+msgid "Exporting logs from %(service_name)s"
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:124
+#, python-format
+msgid ""
+"Failed to save logs for %(service_name)s to %(filepath)s. Exported logs "
+"may be incomplete."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:140
+#, python-format
+msgid ""
+"Failed to export logs for %(service_name)s. Exported logs may be "
+"incomplete."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:149
+#, python-format
+msgid "Exporting logs from %(server_software_name)s CLI"
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:156
+#, python-format
+msgid ""
+"%(server_software_name)s CLI log directory (%(dirpath)s) does not exist; "
+"CLI has never run or has not written any logs."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:170
+#, python-format
+msgid ""
+"%(server_software_name)s CLI log file (%(filepath)s) does not exist; CLI "
+"has never run or has not written any logs."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:181
+#, python-format
+msgid ""
+"Permission denied trying to access %(filepath)s. Permissions may be "
+"incorrect, and exported logs may be incomplete."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:193
+msgid "Exporting logs from PostgreSQL"
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:201
+msgid "Exporting logs from nginx"
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:235
+msgid "Failed to obtain any logs. See errors above. Archive will not be created."
+msgstr ""
+
+#: src/quipucordsctl/commands/export_logs.py:244
+#, python-format
+msgid "Exported logs to %(dest_file)s"
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:33
+#, python-format
+msgid "Installation of %(server_software_name)s completed successfully."
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:56
+#, python-format
+msgid "Install and start the %(server_software_name)s server"
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:93
+#: src/quipucordsctl/commands/upgrade.py:74
+msgid "Automatically enable lingering for the current user (default: --linger)"
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:101
+msgid "Automatically start the server after installation (default: --start)"
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:114
 #, python-format
 msgid "Ensuring directory exists: %(dir_path)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:88
+#: src/quipucordsctl/commands/install.py:126
 msgid "The install command failed to reset encryption secret."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:90
+#: src/quipucordsctl/commands/install.py:128
 msgid "The install command failed to reset session secret."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:91
+#: src/quipucordsctl/commands/install.py:129
 msgid "The install command failed to reset admin username."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:92
+#: src/quipucordsctl/commands/install.py:130
 msgid "The install command failed to reset admin password."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:94
+#: src/quipucordsctl/commands/install.py:132
 msgid "The install command failed to reset database password."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:96
+#: src/quipucordsctl/commands/install.py:134
 msgid "The install command failed to reset redis password."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:118
+#: src/quipucordsctl/commands/install.py:156
 #, python-format
 msgid "No override file found at: %(override_conf_path)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:126
+#: src/quipucordsctl/commands/install.py:164
 #, python-format
 msgid ""
 "Please check file permissions. Cannot read override file at: "
 "%(override_conf_path)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:135
+#: src/quipucordsctl/commands/install.py:173
 #, python-format
 msgid ""
 "Please check file permissions. Cannot access override file at: "
 "%(override_conf_path)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:142
+#: src/quipucordsctl/commands/install.py:180
 #, python-format
 msgid "Override file found at: %(override_conf_path)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:171
+#: src/quipucordsctl/commands/install.py:209
 #, python-format
 msgid ""
 "Skipping overrides for %(template_filename)s due to missing section "
@@ -483,571 +834,590 @@ msgid ""
 "any typos or errors."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:198
+#: src/quipucordsctl/commands/install.py:236
 #, python-format
 msgid ""
 "Overriding %(template_filename)s %(section)s.%(option)s from "
 "%(old_value)s to %(value)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:232
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:277
+#: src/quipucordsctl/commands/install.py:270
+#: src/quipucordsctl/commands/install.py:315
 #, python-format
 msgid "Writing config to %(destination)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:253
+#: src/quipucordsctl/commands/install.py:291
 #, python-format
 msgid ""
 "Appending overrides (%(line_count)s lines) to template for "
 "%(template_filename)s before writing."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:262
+#: src/quipucordsctl/commands/install.py:300
 #, python-format
 msgid ""
 "The following 'override' content was added by the user during "
 "installation at %(now)s"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:269
+#: src/quipucordsctl/commands/install.py:307
 #, python-format
 msgid ""
 "Override file for %(template_filename)s appears to be empty and will be "
 "skipped."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:305
+#: src/quipucordsctl/commands/install.py:323
+msgid "Generating config files"
+msgstr ""
+
+#: src/quipucordsctl/commands/install.py:343
 #, python-format
 msgid "Reloading systemctl to recognize %(server_software_name)s units"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:328
+#: src/quipucordsctl/commands/install.py:361
 #, python-format
 msgid ""
 "The specified override configuration directory ('%(override_conf_dir)s') "
 "does not exist."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/install.py:337
+#: src/quipucordsctl/commands/install.py:405
 msgid "systemctl reload failed unexpectedly. Please check logs."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:28
-msgid "admin login username"
+#: src/quipucordsctl/commands/reset_admin_password.py:31
+msgid "Reset the admin login password"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:36
-msgid "Reset the admin login password."
-msgstr ""
-
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:63
+#: src/quipucordsctl/commands/reset_admin_password.py:58
 msgid "Enter new admin login password: "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:64
+#: src/quipucordsctl/commands/reset_admin_password.py:59
 msgid "Confirm new admin login password: "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:65
+#: src/quipucordsctl/commands/reset_admin_password.py:60
 msgid "The admin login password was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_password.py:66
+#: src/quipucordsctl/commands/reset_admin_password.py:61
 msgid "The admin login password was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:22
-msgid "Reset the admin login username."
+#: src/quipucordsctl/commands/reset_admin_password.py:79
+msgid "admin login username"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:50
-msgid ""
-"Prompt for admin username (default: use environment variable or prompt if"
-" not set)"
+#: src/quipucordsctl/commands/reset_admin_username.py:28
+msgid "Reset the admin login username"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:62
-msgid "Enter admin login username: "
+#: src/quipucordsctl/commands/reset_admin_username.py:55
+msgid "Enter new admin login username: "
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:63
-msgid "Confirm admin login username: "
-msgstr ""
-
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:65
+#: src/quipucordsctl/commands/reset_admin_username.py:57
 msgid ""
 "The admin login username has already been set. Resetting the admin login "
 "username to a new value may prevent you from logging in with the old "
 "username."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:70
+#: src/quipucordsctl/commands/reset_admin_username.py:62
 msgid "Are you sure you want to replace the existing admin login username?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:72
-msgid "Username cannot be empty."
-msgstr ""
-
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:74
+#: src/quipucordsctl/commands/reset_admin_username.py:66
 msgid "Username is required but cannot be prompted in quiet mode."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:76
+#: src/quipucordsctl/commands/reset_admin_username.py:68
 msgid "The admin login username was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_admin_username.py:77
+#: src/quipucordsctl/commands/reset_admin_username.py:69
 msgid "The admin login username was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:24
-msgid "Reset the database password."
+#: src/quipucordsctl/commands/reset_admin_username.py:89
+msgid "admin login password"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:54
+#: src/quipucordsctl/commands/reset_database_password.py:29
+msgid "Reset the database password"
+msgstr ""
+
+#: src/quipucordsctl/commands/reset_database_password.py:61
 msgid ""
 "Prompt for custom database password (default: no prompt, generate a "
 "random value)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:67
+#: src/quipucordsctl/commands/reset_database_password.py:74
+#, python-format
 msgid ""
-"You should only manually reset the database password if you understand "
-"how it is used, and you are addressing a specific issue. We strongly "
-"recommend using the automatically generated value for the database "
-"password instead of manually entering one."
+"%(program_name)s generates cryptographically strong random passwords by "
+"default. You should manually reset the database password only if your "
+"environment specifically requires a custom value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:73
+#: src/quipucordsctl/commands/reset_database_password.py:79
 msgid "Are you sure you want to manually set a custom database password?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:76
+#: src/quipucordsctl/commands/reset_database_password.py:82
 #, python-format
 msgid ""
 "The database password has already been set. Resetting the database "
-"password to a new value may result in data loss if you have already "
-"installed and run %(SERVER_SOFTWARE_NAME)s on this system."
+"password to a new value may break %(SERVER_SOFTWARE_NAME)s or result in "
+"data loss if you have already installed and run %(SERVER_SOFTWARE_NAME)s "
+"on this system."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:83
+#: src/quipucordsctl/commands/reset_database_password.py:90
 msgid "Are you sure you want to replace the existing database password?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:85
+#: src/quipucordsctl/commands/reset_database_password.py:92
 msgid "The database password was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_database_password.py:86
+#: src/quipucordsctl/commands/reset_database_password.py:93
 msgid "The database password was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:24
-msgid "Reset the encryption secret key."
+#: src/quipucordsctl/commands/reset_encryption_secret.py:29
+msgid "Reset the encryption secret key"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:55
+#: src/quipucordsctl/commands/reset_encryption_secret.py:61
 msgid ""
 "Prompt for custom encryption secret key (default: no prompt, generate a "
 "random value)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:68
+#: src/quipucordsctl/commands/reset_encryption_secret.py:74
+#, python-format
 msgid ""
-"You should only manually reset the encryption secret key if you "
-"understand how it is used, and you are addressing a specific issue. We "
-"strongly recommend using the automatically generated value for the "
-"encryption secret key instead of manually entering one."
+"%(program_name)s generates cryptographically strong random passwords by "
+"default. You should manually reset the encryption secret key only if your"
+" environment specifically requires a custom value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:74
+#: src/quipucordsctl/commands/reset_encryption_secret.py:79
 msgid "Are you sure you want to manually set an encryption secret key?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:77
+#: src/quipucordsctl/commands/reset_encryption_secret.py:82
 #, python-format
 msgid ""
 "The encryption secret key has already been set. Resetting the encryption "
-"secret key to a new value may result in data loss if you have already "
-"installed and run %(SERVER_SOFTWARE_NAME)s on this system."
+"secret key to a new value may break %(SERVER_SOFTWARE_NAME)s or result in"
+" data loss if you have already installed and run %(SERVER_SOFTWARE_NAME)s"
+" on this system."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:84
+#: src/quipucordsctl/commands/reset_encryption_secret.py:90
 msgid "Are you sure you want to replace the existing encryption secret key?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:86
+#: src/quipucordsctl/commands/reset_encryption_secret.py:92
 msgid "The encryption secret key was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_encryption_secret.py:87
+#: src/quipucordsctl/commands/reset_encryption_secret.py:93
 msgid "The encryption secret key was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:24
-msgid "Reset the Redis password."
+#: src/quipucordsctl/commands/reset_redis_password.py:29
+msgid "Reset the Redis password"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:54
+#: src/quipucordsctl/commands/reset_redis_password.py:61
 msgid ""
 "Prompt for custom Redis password (default: no prompt, generate a random "
 "value)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:67
+#: src/quipucordsctl/commands/reset_redis_password.py:74
+#, python-format
 msgid ""
-"You should only manually reset the Redis password if you understand how "
-"it is used, and you are addressing a specific issue. We strongly "
-"recommend using the automatically generated value for the Redis password "
-"instead of manually entering one."
+"%(program_name)s generates cryptographically strong random passwords by "
+"default. You should manually reset the Redis password only if your "
+"environment specifically requires a custom value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:73
+#: src/quipucordsctl/commands/reset_redis_password.py:79
 msgid "Are you sure you want to manually set a custom Redis password?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:75
+#: src/quipucordsctl/commands/reset_redis_password.py:81
 msgid "The Redis password was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_redis_password.py:76
+#: src/quipucordsctl/commands/reset_redis_password.py:82
 msgid "The Redis password was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:25
-msgid "Reset the session secret key."
+#: src/quipucordsctl/commands/reset_session_secret.py:30
+msgid "Reset the session secret key"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:57
+#: src/quipucordsctl/commands/reset_session_secret.py:63
 msgid ""
 "Prompt for custom session secret key (default: no prompt, generate a "
 "random value)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:70
+#: src/quipucordsctl/commands/reset_session_secret.py:76
+#, python-format
 msgid ""
-"You should only manually reset the session secret key if you understand "
-"how it is used, and you are addressing a specific issue. We strongly "
-"recommend using the automatically generated value for the session secret "
-"key instead of manually entering one."
+"%(program_name)s generates cryptographically strong random passwords by "
+"default. You should manually reset the session secret key only if your "
+"environment specifically requires a custom value."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:76
+#: src/quipucordsctl/commands/reset_session_secret.py:81
 msgid "Are you sure you want to manually set a custom session secret key?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:79
+#: src/quipucordsctl/commands/reset_session_secret.py:84
 #, python-format
 msgid ""
 "The session secret key has already been set. Resetting the session secret"
-" key to a new value may result in data loss if you have already installed"
-" and run %(SERVER_SOFTWARE_NAME)s on this system."
+" key to a new value may break %(SERVER_SOFTWARE_NAME)s or result in data "
+"loss if you have already installed and run %(SERVER_SOFTWARE_NAME)s on "
+"this system."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:86
+#: src/quipucordsctl/commands/reset_session_secret.py:92
 msgid "Are you sure you want to replace the session secret key?"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:88
+#: src/quipucordsctl/commands/reset_session_secret.py:94
 msgid "The session secret key was successfully updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/reset_session_secret.py:89
+#: src/quipucordsctl/commands/reset_session_secret.py:95
 msgid "The session secret key was not updated."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:16
+#: src/quipucordsctl/commands/start.py:9
 #, python-format
-msgid "Uninstall the %(server_software_name)s server."
+msgid "%(server_software_name)s server started successfully."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:24
+#: src/quipucordsctl/commands/start.py:28
+#, python-format
+msgid "Start the %(server_software_name)s server"
+msgstr ""
+
+#: src/quipucordsctl/commands/uninstall.py:29
+#, python-format
+msgid "Uninstall the %(server_software_name)s server"
+msgstr ""
+
+#: src/quipucordsctl/commands/uninstall.py:57
+#, python-format
+msgid "Do not remove instance data in %(pathname)s (default: remove it)"
+msgstr ""
+
+#: src/quipucordsctl/commands/uninstall.py:65
 #, python-format
 msgid "Removing the %(server_software_name)s container images."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:35
+#: src/quipucordsctl/commands/uninstall.py:76
 msgid ""
 "Podman failed to remove at least one image. Please check logs and "
 "manually remove any remaining images if necessary."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:44
+#: src/quipucordsctl/commands/uninstall.py:87
 #, python-format
 msgid "Removing the %(server_software_name)s file %(file_path)s."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:58
+#: src/quipucordsctl/commands/uninstall.py:101
 #, python-format
 msgid "The uninstall command failed to remove the file %(file_path)s - %(error)s."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:67
+#: src/quipucordsctl/commands/uninstall.py:110
 #, python-format
 msgid ""
 "The uninstall command did not find the file %(file_path)s which it "
 "expected to remove."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:78
+#: src/quipucordsctl/commands/uninstall.py:121
 #, python-format
 msgid "Removing the %(server_software_name)s services."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:114
+#: src/quipucordsctl/commands/uninstall.py:165
+#, python-format
+msgid ""
+"Not removing the %(server_software_name)s data because --keep-data-dirs "
+"flag was passed."
+msgstr ""
+
+#: src/quipucordsctl/commands/uninstall.py:173
 #, python-format
 msgid "Removing the %(server_software_name)s data."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:124
+#: src/quipucordsctl/commands/uninstall.py:184
 #, python-format
 msgid "Removing the %(server_software_name)s secrets."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:135
+#: src/quipucordsctl/commands/uninstall.py:195
 msgid ""
 "Podman failed to remove at least one secret. Please check logs and "
 "manually remove any remaining secrets if necessary."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/uninstall.py:157
+#: src/quipucordsctl/commands/uninstall.py:227
 #, python-format
 msgid "%(server_software_name)s uninstalled successfully."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:16
-#, python-format
-msgid "Upgrade the %(server_software_name)s server."
-msgstr ""
-
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:24
+#: src/quipucordsctl/commands/uninstall.py:233
 #, python-format
 msgid ""
-"The `%(command_name)s` command upgrades the %(server_software_name)s "
-"server if it is already installed or installs the software if not already"
-" installed."
+"%(program_name)s uninstall encountered an unexpected error. Check logs "
+"and manually review that %(server_software_name)s uninstalled completely."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:39
+#: src/quipucordsctl/commands/upgrade.py:21
+#, python-format
+msgid "Upgrade the %(server_software_name)s server"
+msgstr ""
+
+#: src/quipucordsctl/commands/upgrade.py:54
 msgid ""
-"Do not automatically pull the latest podman images (default: pull, "
+"Do not automatically pull the latest container images (default: pull, "
 "requires network connection)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:49
+#: src/quipucordsctl/commands/upgrade.py:64
 #, python-format
 msgid ""
 "Maximum number of seconds to wait for `podman pull` to complete (default:"
 " %(default)s)"
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:71
+#: src/quipucordsctl/commands/upgrade.py:94
 msgid ""
 "Failed to pull at least one image. Please review the logs, check network "
 "connectivity, and verify your podman credentials before trying again."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:105
+#: src/quipucordsctl/commands/upgrade.py:127
 #, python-format
 msgid ""
 "Could not upgrade the %(server_software_name)s software because the "
 "service failed to stop normally."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:119
+#: src/quipucordsctl/commands/upgrade.py:141
 #, python-format
 msgid ""
 "Could not upgrade the %(server_software_name)s software because the "
 "software failed to install normally."
 msgstr ""
 
-#: /home/naragao/work/quipucordsctl/src/quipucordsctl/commands/upgrade.py:129
+#: src/quipucordsctl/commands/upgrade.py:151
 #, python-format
 msgid ""
-"You requested an upgrade without pulling the latest podman images. Please"
-" verify that you have the latest podman images before you restart the "
-"%(server_software_name)s software, or the software may not run correctly."
+"You requested an upgrade without pulling the latest container images. "
+"Please verify that you have the latest container images before you "
+"restart the %(server_software_name)s software, or the software may not "
+"run correctly."
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:228
+#: .../python3.12/argparse.py:228
 #, python-format
 msgid "%(heading)s:"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:300
+#: .../python3.12/argparse.py:300
 msgid "usage: "
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:726
+#: .../python3.12/argparse.py:726
 #, python-format
 msgid " (default: %(default)s)"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:780
+#: .../python3.12/argparse.py:780
 #, python-format
 msgid "argument %(argument_name)s: %(message)s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:886
+#: .../python3.12/argparse.py:886
 msgid ".__call__() not defined"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1157
+#: .../python3.12/argparse.py:1157
 msgid "show program's version number and exit"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1219
+#: .../python3.12/argparse.py:1219
 #, python-format
 msgid "conflicting subparser: %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1223
+#: .../python3.12/argparse.py:1223
 #, python-format
 msgid "conflicting subparser alias: %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1258
+#: .../python3.12/argparse.py:1258
 #, python-format
 msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1318
+#: .../python3.12/argparse.py:1318
 #, python-format
 msgid "argument \"-\" with mode %r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1327
+#: .../python3.12/argparse.py:1327
 #, python-format
 msgid "can't open '%(filename)s': %(error)s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1536
+#: .../python3.12/argparse.py:1536
 #, python-format
 msgid "cannot merge actions - two groups are named %r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1574
+#: .../python3.12/argparse.py:1574
 msgid "'required' is an invalid argument for positionals"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1596
+#: .../python3.12/argparse.py:1596
 #, python-format
 msgid ""
 "invalid option string %(option)r: must start with a character "
 "%(prefix_chars)r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1614
+#: .../python3.12/argparse.py:1614
 #, python-format
 msgid "dest= is required for options like %r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1631
+#: .../python3.12/argparse.py:1631
 #, python-format
 msgid "invalid conflict_resolution value: %r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1649
+#: .../python3.12/argparse.py:1649
 #, python-format
 msgid "conflicting option string: %s"
 msgid_plural "conflicting option strings: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1723
+#: .../python3.12/argparse.py:1723
 msgid "mutually exclusive arguments must be optional"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1799
+#: .../python3.12/argparse.py:1799
 msgid "positional arguments"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1800
+#: .../python3.12/argparse.py:1800
 msgid "options"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1815
+#: .../python3.12/argparse.py:1815
 msgid "show this help message and exit"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1846
+#: .../python3.12/argparse.py:1846
 msgid "cannot have multiple subparser arguments"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:1898
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2421
+#: .../python3.12/argparse.py:1898
+#: .../python3.12/argparse.py:2421
 #, python-format
 msgid "unrecognized arguments: %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2001
+#: .../python3.12/argparse.py:2001
 #, python-format
 msgid "not allowed with argument %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2043
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2074
+#: .../python3.12/argparse.py:2043
+#: .../python3.12/argparse.py:2074
 #, python-format
 msgid "ignored explicit argument %r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2181
+#: .../python3.12/argparse.py:2181
 #, python-format
 msgid "the following arguments are required: %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2196
+#: .../python3.12/argparse.py:2196
 #, python-format
 msgid "one of the arguments %s is required"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2240
+#: .../python3.12/argparse.py:2240
 msgid "expected one argument"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2241
+#: .../python3.12/argparse.py:2241
 msgid "expected at most one argument"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2242
+#: .../python3.12/argparse.py:2242
 msgid "expected at least one argument"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2246
+#: .../python3.12/argparse.py:2246
 #, python-format
 msgid "expected %s argument"
 msgid_plural "expected %s arguments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2303
+#: .../python3.12/argparse.py:2303
 #, python-format
 msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2364
+#: .../python3.12/argparse.py:2364
 #, python-format
 msgid "unexpected option string: %s"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2566
+#: .../python3.12/argparse.py:2566
 #, python-format
 msgid "%r is not callable"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2582
+#: .../python3.12/argparse.py:2582
 #, python-format
 msgid "invalid %(type)s value: %(value)r"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2593
+#: .../python3.12/argparse.py:2593
 #, python-format
 msgid "invalid choice: %(value)r (choose from %(choices)s)"
 msgstr ""
 
-#: ../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/argparse.py:2671
+#: .../python3.12/argparse.py:2671
 #, python-format
 msgid "%(prog)s: error: %(message)s\n"
 msgstr ""

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -70,6 +70,12 @@ SYSTEMCTL_USER_LIST_QUIPUCORDS_APP = [
     "list-unit-files",
     f"{SERVER_SOFTWARE_PACKAGE}-app.service",
 ]
+SYSTEMCTL_USER_START_QUIPUCORDS_APP = [
+    "systemctl",
+    "--user",
+    "start",
+    f"{SERVER_SOFTWARE_PACKAGE}-app",
+]
 SYSTEMCTL_USER_STOP_QUIPUCORDS_APP = [
     "systemctl",
     "--user",
@@ -81,6 +87,19 @@ SYSTEMCTL_USER_STOP_QUIPUCORDS_NETWORK = [
     "--user",
     "stop",
     f"{SERVER_SOFTWARE_PACKAGE}-network",
+]
+SYSTEMCTL_USER_STATUS_QUIPUCORDS_APP = [
+    "systemctl",
+    "--user",
+    "status",
+    f"{SERVER_SOFTWARE_PACKAGE}-app",
+]
+SYSTEMCTL_USER_IS_FAILED_QUIPUCORDS_APP = [
+    "systemctl",
+    "-q",
+    "--user",
+    "is-failed",
+    f"{SERVER_SOFTWARE_PACKAGE}-app.service",
 ]
 
 # podman secrets we use
@@ -95,6 +114,7 @@ QUIPUCORDS_SECRETS = {
 
 QUIPUCORDS_SECRET_KEYS = QUIPUCORDS_SECRETS.values()
 DEFAULT_SUBPROCESS_WAIT_TIMEOUT = 60  # in seconds
+DEFAULT_SERVICE_START_WAIT_TIMEOUT = 120  # in seconds
 DEFAULT_JOURNALCTL_WAIT_TIMEOUT = 300  # in seconds, or 5 minutes
 DEFAULT_PODMAN_PULL_TIMEOUT = 600  # seconds, or 10 minutes
 DEFAULT_PODMAN_REGISTRY = "quay.io"

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -82,6 +82,12 @@ SYSTEMCTL_USER_STOP_QUIPUCORDS_APP = [
     "stop",
     f"{SERVER_SOFTWARE_PACKAGE}-app",
 ]
+SYSTEMCTL_USER_START_QUIPUCORDS_NETWORK = [
+    "systemctl",
+    "--user",
+    "start",
+    f"{SERVER_SOFTWARE_PACKAGE}-network",
+]
 SYSTEMCTL_USER_STOP_QUIPUCORDS_NETWORK = [
     "systemctl",
     "--user",
@@ -114,6 +120,7 @@ QUIPUCORDS_SECRETS = {
 
 QUIPUCORDS_SECRET_KEYS = QUIPUCORDS_SECRETS.values()
 DEFAULT_SUBPROCESS_WAIT_TIMEOUT = 60  # in seconds
+DEFAULT_APP_START_TIMEOUT = 300  # in seconds, 5 minutes
 DEFAULT_SERVICE_START_WAIT_TIMEOUT = 120  # in seconds
 DEFAULT_JOURNALCTL_WAIT_TIMEOUT = 300  # in seconds, or 5 minutes
 DEFAULT_PODMAN_PULL_TIMEOUT = 600  # seconds, or 10 minutes

--- a/src/quipucordsctl/settings.py
+++ b/src/quipucordsctl/settings.py
@@ -99,7 +99,7 @@ SYSTEMCTL_USER_IS_FAILED_QUIPUCORDS_APP = [
     "-q",
     "--user",
     "is-failed",
-    f"{SERVER_SOFTWARE_PACKAGE}-app.service",
+    f"{SERVER_SOFTWARE_PACKAGE}-app",
 ]
 
 # podman secrets we use

--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -2,6 +2,9 @@
 
 import logging
 import os
+import subprocess
+import textwrap
+import time
 from gettext import gettext as _
 
 from quipucordsctl import settings, shell_utils
@@ -99,3 +102,70 @@ def check_service_running() -> bool:
         raise_error=False,
     )
     return status_exit == 0
+
+
+_START_FAILURE_GUIDANCE = textwrap.dedent(
+    _(
+        """
+        %(server_software_name)s failed to start. Check the journal for errors:
+
+            journalctl --user -u %(server_software_package)s-app
+
+        You may also run '%(program_name)s check' for a system health check.
+        """
+    ).strip()
+)
+
+
+def _log_start_failure_details() -> None:
+    """Print service status and log user guidance after a failed start."""
+    stdout, __, __ = shell_utils.run_command(
+        settings.SYSTEMCTL_USER_STATUS_QUIPUCORDS_APP,
+        raise_error=False,
+    )
+    if stdout and not settings.runtime.quiet:
+        print(stdout)
+    logger.error(
+        _(_START_FAILURE_GUIDANCE)
+        % {
+            "server_software_name": settings.SERVER_SOFTWARE_NAME,
+            "server_software_package": settings.SERVER_SOFTWARE_PACKAGE,
+            "program_name": settings.PROGRAM_NAME,
+        }
+    )
+
+
+def start_service() -> bool:
+    """Start quipucords-app and wait until the service becomes active."""
+    logger.info(
+        _("Starting the %(server_software_name)s server."),
+        {"server_software_name": settings.SERVER_SOFTWARE_NAME},
+    )
+    try:
+        shell_utils.run_command(settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP)
+    except subprocess.CalledProcessError:
+        logger.error(
+            _("Failed to issue start command for %(server_software_name)s."),
+            {"server_software_name": settings.SERVER_SOFTWARE_NAME},
+        )
+        _log_start_failure_details()
+        return False
+
+    deadline = time.monotonic() + settings.DEFAULT_SERVICE_START_WAIT_TIMEOUT
+    while time.monotonic() < deadline:
+        if check_service_running():
+            logger.info(
+                _("%(server_software_name)s server is active."),
+                {"server_software_name": settings.SERVER_SOFTWARE_NAME},
+            )
+            return True
+        __, __, failed_exit = shell_utils.run_command(
+            settings.SYSTEMCTL_USER_IS_FAILED_QUIPUCORDS_APP,
+            raise_error=False,
+        )
+        if failed_exit == 0:
+            break
+        time.sleep(5)
+
+    _log_start_failure_details()
+    return False

--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -105,14 +105,14 @@ def check_service_running() -> bool:
             "-q",
             "--user",
             "is-active",
-            f"{settings.SERVER_SOFTWARE_PACKAGE}-app",
+            f"{settings.SERVER_SOFTWARE_PACKAGE}-app.service",
         ],
         raise_error=False,
     )
     return status_exit == 0
 
 
-_START_FAILURE_GUIDANCE = textwrap.dedent(
+START_FAILURE_GUIDANCE = textwrap.dedent(
     _(
         """
         %(server_software_name)s failed to start. Check the journal for errors:
@@ -125,7 +125,7 @@ _START_FAILURE_GUIDANCE = textwrap.dedent(
 )
 
 
-def _log_start_failure_details() -> None:
+def log_start_failure_details() -> None:
     """Print service status and log user guidance after a failed start."""
     stdout, __, __ = shell_utils.run_command(
         settings.SYSTEMCTL_USER_STATUS_QUIPUCORDS_APP,
@@ -134,7 +134,7 @@ def _log_start_failure_details() -> None:
     if stdout and not settings.runtime.quiet:
         print(stdout)
     logger.error(
-        _START_FAILURE_GUIDANCE
+        START_FAILURE_GUIDANCE
         % {
             "server_software_name": settings.SERVER_SOFTWARE_NAME,
             "server_software_package": settings.SERVER_SOFTWARE_PACKAGE,
@@ -161,7 +161,7 @@ def start_service() -> bool:
             _("Failed to issue start command for %(server_software_name)s."),
             {"server_software_name": settings.SERVER_SOFTWARE_NAME},
         )
-        _log_start_failure_details()
+        log_start_failure_details()
         return False
 
     deadline = time.monotonic() + settings.DEFAULT_SERVICE_START_WAIT_TIMEOUT
@@ -180,5 +180,5 @@ def start_service() -> bool:
             break
         time.sleep(5)
 
-    _log_start_failure_details()
+    log_start_failure_details()
     return False

--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -134,7 +134,7 @@ def _log_start_failure_details() -> None:
     if stdout and not settings.runtime.quiet:
         print(stdout)
     logger.error(
-        _(_START_FAILURE_GUIDANCE)
+        _START_FAILURE_GUIDANCE
         % {
             "server_software_name": settings.SERVER_SOFTWARE_NAME,
             "server_software_package": settings.SERVER_SOFTWARE_PACKAGE,

--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -105,7 +105,7 @@ def check_service_running() -> bool:
             "-q",
             "--user",
             "is-active",
-            f"{settings.SERVER_SOFTWARE_PACKAGE}-app.service",
+            f"{settings.SERVER_SOFTWARE_PACKAGE}-app",
         ],
         raise_error=False,
     )
@@ -150,7 +150,12 @@ def start_service() -> bool:
         {"server_software_name": settings.SERVER_SOFTWARE_NAME},
     )
     try:
-        shell_utils.run_command(settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP)
+        shell_utils.run_command(settings.SYSTEMCTL_USER_RESET_FAILED_CMD)
+        shell_utils.run_command(settings.SYSTEMCTL_USER_START_QUIPUCORDS_NETWORK)
+        shell_utils.run_command(
+            settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP,
+            wait_timeout=settings.DEFAULT_APP_START_TIMEOUT,
+        )
     except subprocess.CalledProcessError:
         logger.error(
             _("Failed to issue start command for %(server_software_name)s."),

--- a/src/quipucordsctl/systemctl_utils.py
+++ b/src/quipucordsctl/systemctl_utils.py
@@ -83,6 +83,14 @@ def reload_daemon() -> bool:
     return True
 
 
+def is_service_installed() -> bool:
+    """Return True if the quipucords-app systemd unit file is present."""
+    __, __, exit_code = shell_utils.run_command(
+        settings.SYSTEMCTL_USER_LIST_QUIPUCORDS_APP, raise_error=False
+    )
+    return exit_code == 0
+
+
 def check_service_running() -> bool:
     """Check if quipucords-app service is currently running."""
     logger.debug(

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -310,6 +310,30 @@ def test_install_run_with_no_start_skips_start_service(
         mock_systemctl_utils.start_service.assert_not_called()
 
 
+def test_resolve_override_conf_dir_nonexistent(tmp_path, caplog):
+    """Test _resolve_override_conf_dir returns None and warns for a non-existent dir."""
+    caplog.set_level(logging.WARNING)
+    nonexistent_dir = str(tmp_path / "does_not_exist")
+    result = install._resolve_override_conf_dir(nonexistent_dir)
+    assert result is None
+    assert "does not exist" in caplog.text
+
+
+def test_start_and_print_success_prints_message_on_quiet_false(capsys):
+    """Test _start_and_print_success prints success message when start succeeds."""
+    mock_args = mock.Mock()
+    mock_args.start = True
+    mock_args.quiet = False
+
+    with mock.patch.object(install, "systemctl_utils") as mock_systemctl_utils:
+        mock_systemctl_utils.start_service.return_value = True
+        result = install._start_and_print_success(mock_args)
+
+    assert result is True
+    captured = capsys.readouterr()
+    assert settings.SERVER_SOFTWARE_NAME in captured.out
+
+
 def test_install_run_fails_when_start_service_fails(
     temp_config_directories: dict[str, pathlib.Path], tmp_path: pathlib.Path
 ):

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -311,23 +311,23 @@ def test_install_run_with_no_start_skips_start_service(
 
 
 def test_resolve_override_conf_dir_nonexistent(tmp_path, caplog):
-    """Test _resolve_override_conf_dir returns None and warns for a non-existent dir."""
+    """Test resolve_override_conf_dir returns None and warns for a non-existent dir."""
     caplog.set_level(logging.WARNING)
     nonexistent_dir = str(tmp_path / "does_not_exist")
-    result = install._resolve_override_conf_dir(nonexistent_dir)
+    result = install.resolve_override_conf_dir(nonexistent_dir)
     assert result is None
     assert "does not exist" in caplog.text
 
 
-def test_start_and_print_success_prints_message_on_quiet_false(capsys):
-    """Test _start_and_print_success prints success message when start succeeds."""
+def test_start_server_prints_message_on_quiet_false(capsys):
+    """Test start_server prints success message when start succeeds."""
     mock_args = mock.Mock()
     mock_args.start = True
     mock_args.quiet = False
 
     with mock.patch.object(install, "systemctl_utils") as mock_systemctl_utils:
         mock_systemctl_utils.start_service.return_value = True
-        result = install._start_and_print_success(mock_args)
+        result = install.start_server(mock_args)
 
     assert result is True
     captured = capsys.readouterr()

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -35,6 +35,9 @@ def test_get_description():
         (["--linger"], "linger", True),
         (["--no-linger"], "linger", False),
         ([], "linger", True),
+        (["--start"], "start", True),
+        (["--no-start"], "start", False),
+        ([], "start", True),
     ),
 )
 def test_setup_parser(args, attr_name, expected):
@@ -89,6 +92,8 @@ def test_install_run(
     ):
         reset_secrets.return_value = True
         loginctl_utils.enable_linger.return_value = True
+        systemctl_utils.start_service.return_value = True
+        mock_args.start = True
 
         install.run(mock_args)
 
@@ -98,6 +103,7 @@ def test_install_run(
         reset_secrets.assert_called_once_with(mock_args)
         systemctl_reload.assert_called_once()
         loginctl_utils.enable_linger.assert_called_once()
+        systemctl_utils.start_service.assert_called_once()
 
         # Spot-check only a few paths that should now exist.
         assert (data_dir / "data").is_dir()
@@ -235,16 +241,18 @@ def test_install_run_ensure_images_called(
     """Test that install calls ensure_images."""
     mock_args = mock.Mock()
     mock_args.override_conf_dir = None
+    mock_args.start = True
 
     with (
         mock.patch.object(install, "podman_utils") as mock_podman_utils,
-        mock.patch.object(install, "systemctl_utils"),
+        mock.patch.object(install, "systemctl_utils") as mock_systemctl_utils,
         mock.patch.object(install, "reset_secrets", return_value=True),
         mock.patch.object(install, "systemctl_reload"),
         mock.patch.object(install, "loginctl_utils") as mock_loginctl_utils,
     ):
         mock_podman_utils.ensure_images.return_value = True
         mock_loginctl_utils.enable_linger.return_value = True
+        mock_systemctl_utils.start_service.return_value = True
 
         result = install.run(mock_args)
 
@@ -258,6 +266,7 @@ def test_install_run_fails_when_ensure_images_fails(
     """Test that install returns False when ensure_images fails."""
     mock_args = mock.Mock()
     mock_args.override_conf_dir = None
+    mock_args.start = True
 
     with (
         mock.patch.object(install, "podman_utils") as mock_podman_utils,
@@ -274,3 +283,53 @@ def test_install_run_fails_when_ensure_images_fails(
         assert result is False
         mock_podman_utils.ensure_images.assert_called_once()
         mock_loginctl_utils.enable_linger.assert_not_called()
+
+
+def test_install_run_with_no_start_skips_start_service(
+    temp_config_directories: dict[str, pathlib.Path], tmp_path: pathlib.Path
+):
+    """Test that install with --no-start does not call start_service."""
+    mock_args = mock.Mock()
+    mock_args.override_conf_dir = None
+    mock_args.start = False
+    mock_args.quiet = False
+
+    with (
+        mock.patch.object(install, "podman_utils") as mock_podman_utils,
+        mock.patch.object(install, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(install, "reset_secrets", return_value=True),
+        mock.patch.object(install, "systemctl_reload"),
+        mock.patch.object(install, "loginctl_utils") as mock_loginctl_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_loginctl_utils.enable_linger.return_value = True
+
+        result = install.run(mock_args)
+
+        assert result is True
+        mock_systemctl_utils.start_service.assert_not_called()
+
+
+def test_install_run_fails_when_start_service_fails(
+    temp_config_directories: dict[str, pathlib.Path], tmp_path: pathlib.Path
+):
+    """Test that install returns False when start_service fails."""
+    mock_args = mock.Mock()
+    mock_args.override_conf_dir = None
+    mock_args.start = True
+
+    with (
+        mock.patch.object(install, "podman_utils") as mock_podman_utils,
+        mock.patch.object(install, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(install, "reset_secrets", return_value=True),
+        mock.patch.object(install, "systemctl_reload"),
+        mock.patch.object(install, "loginctl_utils") as mock_loginctl_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_loginctl_utils.enable_linger.return_value = True
+        mock_systemctl_utils.start_service.return_value = False
+
+        result = install.run(mock_args)
+
+        assert result is False
+        mock_systemctl_utils.start_service.assert_called_once()

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -1,0 +1,116 @@
+"""Test the "start" command."""
+
+from unittest import mock
+
+from quipucordsctl import argparse_utils, settings
+from quipucordsctl.commands import start
+
+
+def test_get_help():
+    """Test get_help returns an appropriate string."""
+    assert settings.SERVER_SOFTWARE_NAME in start.get_help()
+
+
+def test_get_description():
+    """Test get_description returns an appropriate string."""
+    assert settings.SERVER_SOFTWARE_NAME in start.get_description()
+
+
+def test_get_display_group():
+    """Test get_display_group returns MAIN."""
+    assert start.get_display_group() == argparse_utils.DisplayGroups.MAIN
+
+
+def test_start_run_happy_path():
+    """Test the start command happy path."""
+    mock_args = mock.Mock()
+    mock_args.quiet = False
+
+    with (
+        mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(start, "podman_utils") as mock_podman_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_systemctl_utils.start_service.return_value = True
+
+        result = start.run(mock_args)
+
+        assert result is True
+        mock_systemctl_utils.ensure_systemd_user_session.assert_called_once()
+        mock_podman_utils.ensure_podman_socket.assert_called_once()
+        mock_podman_utils.ensure_cgroups_v2.assert_called_once()
+        mock_podman_utils.ensure_images.assert_called_once()
+        mock_systemctl_utils.start_service.assert_called_once()
+
+
+def test_start_run_fails_when_ensure_images_fails():
+    """Test start returns False when ensure_images fails."""
+    mock_args = mock.Mock()
+
+    with (
+        mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(start, "podman_utils") as mock_podman_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = False
+
+        result = start.run(mock_args)
+
+        assert result is False
+        mock_podman_utils.ensure_images.assert_called_once()
+        mock_systemctl_utils.start_service.assert_not_called()
+
+
+def test_start_run_fails_when_start_service_fails():
+    """Test start returns False when start_service fails."""
+    mock_args = mock.Mock()
+    mock_args.quiet = False
+
+    with (
+        mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(start, "podman_utils") as mock_podman_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_systemctl_utils.start_service.return_value = False
+
+        result = start.run(mock_args)
+
+        assert result is False
+        mock_systemctl_utils.start_service.assert_called_once()
+
+
+def test_start_run_quiet_suppresses_success_message(capsys):
+    """Test that --quiet suppresses the success print."""
+    mock_args = mock.Mock()
+    mock_args.quiet = True
+
+    with (
+        mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(start, "podman_utils") as mock_podman_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_systemctl_utils.start_service.return_value = True
+
+        result = start.run(mock_args)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+def test_start_run_prints_success_message(capsys):
+    """Test that success message is printed when not quiet."""
+    mock_args = mock.Mock()
+    mock_args.quiet = False
+
+    with (
+        mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils,
+        mock.patch.object(start, "podman_utils") as mock_podman_utils,
+    ):
+        mock_podman_utils.ensure_images.return_value = True
+        mock_systemctl_utils.start_service.return_value = True
+
+        result = start.run(mock_args)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert settings.SERVER_SOFTWARE_NAME in captured.out

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -21,6 +21,23 @@ def test_get_display_group():
     assert start.get_display_group() == argparse_utils.DisplayGroups.MAIN
 
 
+def test_start_run_fails_when_not_installed(capsys):
+    """Test start returns False with a message when service is not installed."""
+    mock_args = mock.Mock()
+
+    with mock.patch.object(start, "systemctl_utils") as mock_systemctl_utils:
+        mock_systemctl_utils.is_service_installed.return_value = False
+
+        result = start.run(mock_args)
+
+        assert result is False
+        mock_systemctl_utils.is_service_installed.assert_called_once()
+        mock_systemctl_utils.ensure_systemd_user_session.assert_not_called()
+        captured = capsys.readouterr()
+        assert settings.PROGRAM_NAME in captured.out
+        assert "install" in captured.out
+
+
 def test_start_run_happy_path():
     """Test the start command happy path."""
     mock_args = mock.Mock()

--- a/tests/test_systemctl_utils.py
+++ b/tests/test_systemctl_utils.py
@@ -93,6 +93,18 @@ def test_invalid_systemd_user_session_systemctl_error(mock_shell_utils):
     )
 
 
+def test_is_service_installed_when_installed(mock_shell_utils):
+    """Test is_service_installed returns True when the service unit is present."""
+    mock_shell_utils.run_command.return_value = ("", "", 0)
+    assert systemctl_utils.is_service_installed() is True
+
+
+def test_is_service_installed_when_not_installed(mock_shell_utils):
+    """Test is_service_installed returns False when the service unit is not present."""
+    mock_shell_utils.run_command.return_value = ("", "", 1)
+    assert systemctl_utils.is_service_installed() is False
+
+
 def test_check_service_running_when_active(mock_shell_utils):
     """Test check_service_running returns True when service is active."""
     mock_shell_utils.run_command.return_value = ("", "", 0)

--- a/tests/test_systemctl_utils.py
+++ b/tests/test_systemctl_utils.py
@@ -141,18 +141,14 @@ def test_log_start_failure_details_quiet_suppresses_stdout(mock_shell_utils, cap
 
 def test_start_service_happy_path(mock_shell_utils):
     """Test start_service returns True when service becomes active quickly."""
-    # start succeeds, then is-active returns 0 (active)
     mock_shell_utils.run_command.side_effect = [
-        ("", "", 0),  # systemctl start
-        ("", "", 0),  # is-active → active
+        ("", "", 0),  # systemctl reset-failed
+        ("", "", 0),  # systemctl start network
+        ("", "", 0),  # systemctl start app
     ]
 
     with mock.patch.object(systemctl_utils, "check_service_running", return_value=True):
         assert systemctl_utils.start_service()
-
-    mock_shell_utils.run_command.assert_called_once_with(
-        settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP
-    )
 
 
 def test_start_service_polls_until_active(mock_shell_utils):
@@ -160,7 +156,9 @@ def test_start_service_polls_until_active(mock_shell_utils):
     # start succeeds; is-failed returns 1 (not failed) for each wait iteration;
     # on the 3rd check_service_running call, the service is active and we stop.
     mock_shell_utils.run_command.side_effect = [
-        ("", "", 0),  # systemctl start
+        ("", "", 0),  # systemctl reset-failed
+        ("", "", 0),  # systemctl start network
+        ("", "", 0),  # systemctl start app
         ("", "", 1),  # is-failed: exit 1 = service is NOT failed (still starting)
         ("", "", 1),  # is-failed: exit 1 = service is NOT failed (still starting)
         # 3rd check_service_running returns True, so is-failed is never called again
@@ -203,7 +201,9 @@ def test_start_service_fails_on_failed_state(mock_shell_utils):
         mock_time.monotonic.side_effect = [0, 0, 10]
         # is-failed returns 0 (service IS failed)
         mock_shell_utils.run_command.side_effect = [
-            ("", "", 0),  # systemctl start
+            ("", "", 0),  # systemctl reset-failed
+            ("", "", 0),  # systemctl start network
+            ("", "", 0),  # systemctl start app
             ("", "", 0),  # is-failed → failed (exit 0 means IS failed)
         ]
 
@@ -233,7 +233,9 @@ def test_start_service_timeout(mock_shell_utils):
     ):
         # is-failed returns 1 (not failed yet), but deadline expires immediately
         mock_shell_utils.run_command.side_effect = [
-            ("", "", 0),  # systemctl start
+            ("", "", 0),  # systemctl reset-failed
+            ("", "", 0),  # systemctl start network
+            ("", "", 0),  # systemctl start app
         ]
         # First monotonic call sets deadline, second is already past it
         mock_time.monotonic.side_effect = [0, 999]

--- a/tests/test_systemctl_utils.py
+++ b/tests/test_systemctl_utils.py
@@ -1,6 +1,7 @@
 """Test the systemctl_utils module."""
 
 import os
+import subprocess
 from unittest import mock
 
 import pytest
@@ -90,3 +91,140 @@ def test_invalid_systemd_user_session_systemctl_error(mock_shell_utils):
     mock_shell_utils.run_command.assert_called_once_with(
         settings.SYSTEMCTL_USER_IS_SYSTEM_RUNNING_CMD
     )
+
+
+def test_check_service_running_when_active(mock_shell_utils):
+    """Test check_service_running returns True when service is active."""
+    mock_shell_utils.run_command.return_value = ("", "", 0)
+    assert systemctl_utils.check_service_running() is True
+
+
+def test_check_service_running_when_inactive(mock_shell_utils):
+    """Test check_service_running returns False when service is not active."""
+    mock_shell_utils.run_command.return_value = ("", "", 1)
+    assert systemctl_utils.check_service_running() is False
+
+
+def test_log_start_failure_details_prints_stdout(mock_shell_utils, capsys):
+    """Test _log_start_failure_details prints status output when not quiet."""
+    mock_shell_utils.run_command.return_value = ("service status output", "", 1)
+    with mock.patch.object(systemctl_utils.settings, "runtime") as mock_runtime:
+        mock_runtime.quiet = False
+        systemctl_utils._log_start_failure_details()
+
+    captured = capsys.readouterr()
+    assert "service status output" in captured.out
+
+
+def test_log_start_failure_details_quiet_suppresses_stdout(mock_shell_utils, capsys):
+    """Test _log_start_failure_details skips printing status output in quiet mode."""
+    mock_shell_utils.run_command.return_value = ("service status output", "", 1)
+    with mock.patch.object(systemctl_utils.settings, "runtime") as mock_runtime:
+        mock_runtime.quiet = True
+        systemctl_utils._log_start_failure_details()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_start_service_happy_path(mock_shell_utils):
+    """Test start_service returns True when service becomes active quickly."""
+    # start succeeds, then is-active returns 0 (active)
+    mock_shell_utils.run_command.side_effect = [
+        ("", "", 0),  # systemctl start
+        ("", "", 0),  # is-active → active
+    ]
+
+    with mock.patch.object(systemctl_utils, "check_service_running", return_value=True):
+        assert systemctl_utils.start_service()
+
+    mock_shell_utils.run_command.assert_called_once_with(
+        settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP
+    )
+
+
+def test_start_service_polls_until_active(mock_shell_utils):
+    """Test start_service polls and succeeds after a few iterations."""
+    # start succeeds; is-failed returns 1 (not failed) for each wait iteration;
+    # on the 3rd check_service_running call, the service is active and we stop.
+    mock_shell_utils.run_command.side_effect = [
+        ("", "", 0),  # systemctl start
+        ("", "", 1),  # is-failed: exit 1 = service is NOT failed (still starting)
+        ("", "", 1),  # is-failed: exit 1 = service is NOT failed (still starting)
+        # 3rd check_service_running returns True, so is-failed is never called again
+    ]
+
+    call_count = 0
+
+    def check_running_side_effect():
+        nonlocal call_count
+        call_count += 1
+        return call_count >= 3  # active on the 3rd poll
+
+    with (
+        mock.patch.object(
+            systemctl_utils,
+            "check_service_running",
+            side_effect=check_running_side_effect,
+        ),
+        mock.patch.object(systemctl_utils, "time") as mock_time,
+    ):
+        # monotonic returns values that won't expire the deadline
+        mock_time.monotonic.side_effect = [0, 0, 10, 20, 30, 40, 50]
+        assert systemctl_utils.start_service()
+
+    assert call_count == 3
+
+
+def test_start_service_fails_on_failed_state(mock_shell_utils):
+    """Test start_service returns False when service enters failed state."""
+    mock_shell_utils.run_command.side_effect = [
+        ("", "", 0),  # systemctl start
+        ("status output", "", 1),  # status (called in _log_start_failure_details)
+    ]
+
+    with (
+        mock.patch.object(systemctl_utils, "check_service_running", return_value=False),
+        mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log,
+        mock.patch.object(systemctl_utils, "time") as mock_time,
+    ):
+        mock_time.monotonic.side_effect = [0, 0, 10]
+        # is-failed returns 0 (service IS failed)
+        mock_shell_utils.run_command.side_effect = [
+            ("", "", 0),  # systemctl start
+            ("", "", 0),  # is-failed → failed (exit 0 means IS failed)
+        ]
+
+        assert not systemctl_utils.start_service()
+        mock_log.assert_called_once()
+
+
+def test_start_service_fails_when_start_command_raises(mock_shell_utils):
+    """Test start_service returns False when systemctl start command itself fails."""
+    mock_shell_utils.run_command.side_effect = subprocess.CalledProcessError(
+        1, settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP
+    )
+
+    with mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log:
+        assert not systemctl_utils.start_service()
+        mock_log.assert_called_once()
+
+
+def test_start_service_timeout(mock_shell_utils):
+    """Test start_service returns False when timeout is exceeded."""
+    mock_shell_utils.run_command.return_value = ("", "", 0)
+
+    with (
+        mock.patch.object(systemctl_utils, "check_service_running", return_value=False),
+        mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log,
+        mock.patch.object(systemctl_utils, "time") as mock_time,
+    ):
+        # is-failed returns 1 (not failed yet), but deadline expires immediately
+        mock_shell_utils.run_command.side_effect = [
+            ("", "", 0),  # systemctl start
+        ]
+        # First monotonic call sets deadline, second is already past it
+        mock_time.monotonic.side_effect = [0, 999]
+
+        assert not systemctl_utils.start_service()
+        mock_log.assert_called_once()

--- a/tests/test_systemctl_utils.py
+++ b/tests/test_systemctl_utils.py
@@ -118,25 +118,35 @@ def test_check_service_running_when_inactive(mock_shell_utils):
 
 
 def test_log_start_failure_details_prints_stdout(mock_shell_utils, capsys):
-    """Test _log_start_failure_details prints status output when not quiet."""
+    """Test log_start_failure_details prints status output when not quiet."""
     mock_shell_utils.run_command.return_value = ("service status output", "", 1)
     with mock.patch.object(systemctl_utils.settings, "runtime") as mock_runtime:
         mock_runtime.quiet = False
-        systemctl_utils._log_start_failure_details()
+        systemctl_utils.log_start_failure_details()
 
     captured = capsys.readouterr()
     assert "service status output" in captured.out
 
 
 def test_log_start_failure_details_quiet_suppresses_stdout(mock_shell_utils, capsys):
-    """Test _log_start_failure_details skips printing status output in quiet mode."""
+    """Test log_start_failure_details skips printing status output in quiet mode."""
     mock_shell_utils.run_command.return_value = ("service status output", "", 1)
     with mock.patch.object(systemctl_utils.settings, "runtime") as mock_runtime:
         mock_runtime.quiet = True
-        systemctl_utils._log_start_failure_details()
+        systemctl_utils.log_start_failure_details()
 
     captured = capsys.readouterr()
     assert captured.out == ""
+
+
+def test_log_start_failure_details_logs_guidance_message(mock_shell_utils, caplog):
+    """Test log_start_failure_details always logs guidance via logger.error."""
+    mock_shell_utils.run_command.return_value = ("service status output", "", 1)
+    with mock.patch.object(systemctl_utils.settings, "runtime") as mock_runtime:
+        mock_runtime.quiet = True
+        systemctl_utils.log_start_failure_details()
+
+    assert any("journalctl --user -u" in r.message for r in caplog.records)
 
 
 def test_start_service_happy_path(mock_shell_utils):
@@ -188,14 +198,9 @@ def test_start_service_polls_until_active(mock_shell_utils):
 
 def test_start_service_fails_on_failed_state(mock_shell_utils):
     """Test start_service returns False when service enters failed state."""
-    mock_shell_utils.run_command.side_effect = [
-        ("", "", 0),  # systemctl start
-        ("status output", "", 1),  # status (called in _log_start_failure_details)
-    ]
-
     with (
         mock.patch.object(systemctl_utils, "check_service_running", return_value=False),
-        mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log,
+        mock.patch.object(systemctl_utils, "log_start_failure_details") as mock_log,
         mock.patch.object(systemctl_utils, "time") as mock_time,
     ):
         mock_time.monotonic.side_effect = [0, 0, 10]
@@ -217,7 +222,7 @@ def test_start_service_fails_when_start_command_raises(mock_shell_utils):
         1, settings.SYSTEMCTL_USER_START_QUIPUCORDS_APP
     )
 
-    with mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log:
+    with mock.patch.object(systemctl_utils, "log_start_failure_details") as mock_log:
         assert not systemctl_utils.start_service()
         mock_log.assert_called_once()
 
@@ -228,7 +233,7 @@ def test_start_service_timeout(mock_shell_utils):
 
     with (
         mock.patch.object(systemctl_utils, "check_service_running", return_value=False),
-        mock.patch.object(systemctl_utils, "_log_start_failure_details") as mock_log,
+        mock.patch.object(systemctl_utils, "log_start_failure_details") as mock_log,
         mock.patch.object(systemctl_utils, "time") as mock_time,
     ):
         # is-failed returns 1 (not failed yet), but deadline expires immediately


### PR DESCRIPTION
feat: Adding support for server start command
    
- Adding the start subcommand
- Updating the install command to auto-start the server
- Adding the --no-start option (default to --start) to the install command
- Adding test for the new command and test coverage
- Make sure start checks that the quipucords-app service is installed
- Display error message accordingly
- Adding tests for this check/verification

Requires: https://gitlab.cee.redhat.com/discovery/discovery-ci/-/merge_requests/209

Successful Stand-alone jobs: https://jenkins-csb-smqe-stage.dno.corp.redhat.com/view/Discovery/job/discovery-standalone/430/

Solves: https://redhat.atlassian.net/browse/DISCOVERY-1118



## Summary by Sourcery

Add a dedicated CLI command to start the server and integrate automatic server startup into the install workflow, with corresponding systemd helpers and robustness improvements.

New Features:
- Introduce a `start` CLI command that validates installation, prepares the environment, and starts the server while providing user-facing status messages.
- Add an optional `--start/--no-start` flag to the install command to control whether the server is started automatically after installation.

Enhancements:
- Update install command messaging to distinguish between installs that auto-start the server and those that do not, and to reference the new start command.
- Add systemd utility helpers to detect whether the service is installed, start it with polling and timeout handling, and emit detailed guidance when startup fails.
- Refactor install command logic to reuse override-configuration directory resolution and to delegate post-install startup and messaging to a helper function.
- Extend settings with systemctl commands and a configurable service start wait timeout to support the new startup flow.

Tests:
- Add unit tests for the new start command covering success, failure, quiet mode, and service-not-installed behavior.
- Expand systemctl utilities tests to cover service-running checks, start behavior under various conditions, and logging of failure details.
- Update install command tests to cover the new start flag behavior, integration with start_service, and failure scenarios when startup fails.

## Summary by Sourcery

Add a dedicated CLI command to start the server and integrate automatic startup into the install workflow, with supporting systemd utilities and messages.

New Features:
- Introduce a `start` CLI command that validates installation, prepares the environment, and starts the server.
- Add a `--start/--no-start` flag to the install command to control automatic server startup and adjust success messaging accordingly.

Enhancements:
- Refine installation success messages and introduce helpers for resolving override configuration directories and delegating post-install server startup.
- Extend systemd utility helpers with service installation detection, a robust service start routine with timeouts and failure handling, and localized guidance for troubleshooting.
- Update localization extraction script and templates to cover new translatable strings.

Tests:
- Add unit tests for the new `start` command covering success, failure, quiet mode, and missing-service behavior.
- Expand systemctl utilities tests to cover service installation checks, start logic under various conditions, and failure logging behavior.
- Update install command tests for the new start flag, override config directory resolution, and behavior when automatic startup is enabled, disabled, or fails.