### PR TITLE
fix: hide the upgrade command from the CLI help text until we are ready to advertise and support it

### DIFF
--- a/src/quipucordsctl/argparse_utils.py
+++ b/src/quipucordsctl/argparse_utils.py
@@ -45,9 +45,13 @@ def add_command(  # noqa: PLR0913
     usage = _("{prog} [OPTIONS...] {name} [COMMAND OPTIONS...]").format(
         prog=settings.PROGRAM_NAME, name=command_name
     )
+
+    # Check if this command should be hidden from help text
+    is_hidden = getattr(command_module, "HIDDEN_COMMAND", False)
+
     command_parser = subparser.add_parser(
         command_name,
-        help=help_text,
+        help=argparse.SUPPRESS if is_hidden else help_text,
         description=description,
         epilog=epilog,
         usage=usage,
@@ -59,6 +63,8 @@ def add_command(  # noqa: PLR0913
     # The above call to subparser.add_parser *should always* append to _choices_actions.
     # If future Python internals have changed unexpectedly, this will fail loudly and
     # raise an exception to the top of the stack, ending execution.
+    # Note: For hidden commands, we still add them to the display group to maintain
+    # consistency, even though they won't be shown in help text.
     try:
         if subparser._choices_actions[-1].dest == command_name:
             argparse_display_group._group_actions.append(subparser._choices_actions[-1])

--- a/src/quipucordsctl/commands/upgrade.py
+++ b/src/quipucordsctl/commands/upgrade.py
@@ -10,6 +10,8 @@ from quipucordsctl.commands import install
 
 logger = logging.getLogger(__name__)
 
+HIDDEN_COMMAND = True
+
 
 def get_display_group() -> argparse_utils.DisplayGroups:
     """Get the group identifier for displaying this command in CLI help text."""

--- a/tests/test_argparse_utils.py
+++ b/tests/test_argparse_utils.py
@@ -29,7 +29,7 @@ def test_add_command(faker):
     middle_argument_group = parser.add_argument_group(faker.slug())
     parser.add_argument_group(faker.slug())  # extra to force checking multiple groups
 
-    mock_command = mock.Mock()
+    mock_command = mock.Mock(spec=["setup_parser"])
     command_name = faker.slug()
     command_help = faker.sentence()
     command_description = faker.sentence()
@@ -63,5 +63,48 @@ def test_add_command(faker):
     mock_command.setup_parser.assert_called_once()
     assert action.dest == command_name
     assert action.help == command_help
+    assert subparsers.choices[command_name].description == command_description
+    assert subparsers.choices[command_name].epilog == command_epilog
+
+
+def test_add_command_hidden(faker):
+    """Test add_command with HIDDEN_COMMAND=True suppresses help text."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    middle_argument_group = parser.add_argument_group(faker.slug())
+
+    mock_command = mock.Mock(spec=["setup_parser"])
+    mock_command.HIDDEN_COMMAND = True
+    command_name = faker.slug()
+    command_help = faker.sentence()
+    command_description = faker.sentence()
+    command_epilog = faker.sentence()
+
+    argparse_utils.add_command(
+        subparsers,
+        mock_command,
+        middle_argument_group,
+        command_name,
+        command_help,
+        command_description,
+        command_epilog,
+    )
+
+    argparse_group = next(
+        filter(
+            lambda _group: _group.title == middle_argument_group.title,
+            parser._action_groups,
+        )
+    )
+    action = next(
+        filter(
+            lambda _action: _action.dest == command_name,
+            argparse_group._group_actions,
+        )
+    )
+
+    mock_command.setup_parser.assert_called_once()
+    assert action.dest == command_name
+    assert action.help == argparse.SUPPRESS  # Help text should be suppressed
     assert subparsers.choices[command_name].description == command_description
     assert subparsers.choices[command_name].epilog == command_epilog


### PR DESCRIPTION
Output after this change:

```
$ XDG_RUNTIME_DIR=$TMPDIR uv run quipucordsctl --help
usage: quipucordsctl [OPTIONS...] COMMAND [COMMAND OPTIONS...]

Configure and manage local Quipucords services.

options:
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbose output
  -y, --yes             Automatically answer 'y' to all confirmation prompts
  -q, --quiet           Quiet output (overrides `-v`/`--verbose`)
  --color, -C {auto,always,never}
                        Control the use of color in output
  -c, --override-conf-dir OVERRIDE_CONF_DIR
                        Override configuration directory

Main Commands:
  install               Install the Quipucords server
  uninstall             Uninstall the Quipucords server

Diagnostic Commands:
  check                 Check config files and directories
  export_logs           Export Quipucords logs

Advanced Configuration Commands:
  reset_admin_password  Reset the admin login password
  reset_admin_username  Reset the admin login username
  reset_database_password
                        Reset the database password
  reset_encryption_secret
                        Reset the encryption secret key
  reset_redis_password  Reset the Redis password
  reset_session_secret  Reset the session secret key
```

We can still run the command for local development and testing. It's just _hidden_ from the top level CLI args.

```
$ XDG_RUNTIME_DIR=$TMPDIR uv run quipucordsctl upgrade --help
usage: quipucordsctl [OPTIONS...] upgrade [COMMAND OPTIONS...]

Upgrade the Quipucords software if it is already installed, or install the software if it is not present. The `upgrade` command will stop any
currently running Quipucords services before attempting to upgrade them. The `upgrade` command may attempt to pull new images from the remote
container registry, and that operation may require you to run a `podman login` command separately to refresh your registry credentials.

options:
  -h, --help            show this help message and exit
  -P, --no-pull         Do not automatically pull the latest container images (default: pull, requires network connection)
  -t, --timeout TIMEOUT
                        Maximum number of seconds to wait for `podman pull` to complete (default: 600)
  --linger, --no-linger
                        Automatically enable lingering for the current user (default: --linger)
```

## Summary by Sourcery

Enhancements:
- Mark the upgrade command as non-discoverable so it no longer appears in standard CLI help text.