### PR TITLE
feat: add man page for quipucordsctl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           [
             lint,
             test-coverage,
+            manpage-test,
           ]
         python-version: ["3.12"]
     runs-on: ubuntu-latest
@@ -57,6 +58,10 @@ jobs:
 
       - name: Install Python dependencies
         run: uv sync
+
+      - name: Install build dependencies for manpage test
+        if: ${{ contains(matrix.type, 'manpage-test') }}
+        run: uv sync --group build
 
       - name: Run Test
         run: make ${{ matrix.type }} TEST_TIMEOUT=1.0 TEST_SESSION_TIMEOUT=10.0 -k

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.xml
 quipucordsctl.egg-info
 build
 .python-version
+docs/_build/.doctrees/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ TEST_TIMEOUT ?= "0.5"
 TEST_SESSION_TIMEOUT ?= "5.0"
 TEST_OPTS := -ra --timeout=$(TEST_TIMEOUT) --session-timeout=$(TEST_SESSION_TIMEOUT)
 
+# Man page generation variables
+PKG_VERSION = $(shell uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+BUILD_DATE = $(shell date '+%B %d, %Y')
+QUIPUCORDSCTL_VAR_CURRENT_YEAR = $(shell date '+%Y')
+QUIPUCORDSCTL_VAR_PROGRAM_NAME = quipucordsctl
+QUIPUCORDSCTL_VAR_PROJECT = Quipucords
+OLD_MAN_PAGE_BUILD_DATE := $(shell grep -e "^\.TH" docs/_build/quipucordsctl.1 2>/dev/null | cut -d '"' -f 6)
+SED = sed
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  help                          to show this message"
@@ -15,6 +24,8 @@ help:
 	@echo "  update-requirements           to update all python dependencies"
 	@echo "  test                          to run unit tests"
 	@echo "  test-coverage                 to run unit tests and measure test coverage"
+	@echo "  manpage                       to regenerate all man page files"
+	@echo "  manpage-test                  to verify man pages haven't changed (CI)"
 
 all: check-requirements lint test-coverage
 
@@ -48,3 +59,64 @@ lint: lint-ruff
 lint-ruff:
 	uv run ruff check .
 	uv run ruff format --check .
+
+# Man page generation targets
+
+.PHONY: manpage manpage-test update-man-template-roff update-man-quipucordsctl-rst update-man-quipucordsctl-roff generate-man-quipucordsctl-rst generate-man-quipucordsctl-roff
+
+# Write a man page (roff format) with placeholders for names, version, and dates
+update-man-template-roff:
+	@SPHINX_BUILD=$$(uv run which sphinx-build 2>/dev/null); \
+	if [ -z "$$SPHINX_BUILD" ]; then \
+		echo "Error: sphinx-build not found. Install with: uv sync --group build"; \
+		exit 1; \
+	fi; \
+	$$SPHINX_BUILD -b man -q \
+	  -D project='QUIPUCORDSCTL_VAR_PROGRAM_NAME' \
+	  -D release='PKG_VERSION' \
+	  -D today='BUILD_DATE' \
+	  docs/source docs/_build
+
+# Generate an upstream "quipucordsctl" man page in human-readable RST
+generate-man-quipucordsctl-rst:
+	@$(SED) \
+	  -e "s/QUIPUCORDSCTL_VAR_PROGRAM_NAME/${QUIPUCORDSCTL_VAR_PROGRAM_NAME}/g" \
+	  -e "s/QUIPUCORDSCTL_VAR_PROJECT/${QUIPUCORDSCTL_VAR_PROJECT}/g" \
+	  -e "s/QUIPUCORDSCTL_VAR_CURRENT_YEAR/${QUIPUCORDSCTL_VAR_CURRENT_YEAR}/g" \
+	  docs/source/man-template.rst
+
+update-man-quipucordsctl-rst:
+	$(MAKE) --no-print-directory generate-man-quipucordsctl-rst > docs/_build/man-quipucordsctl.rst
+
+# Generate an upstream "quipucordsctl" man page in man-parsable roff format
+generate-man-quipucordsctl-roff:
+	@$(SED) \
+	  -e "s/QUIPUCORDSCTL_VAR_PROGRAM_NAME/${QUIPUCORDSCTL_VAR_PROGRAM_NAME}/g" \
+	  -e "s/QUIPUCORDSCTL_VAR_PROJECT/${QUIPUCORDSCTL_VAR_PROJECT}/g" \
+	  -e "s/QUIPUCORDSCTL_VAR_CURRENT_YEAR/${QUIPUCORDSCTL_VAR_CURRENT_YEAR}/g" \
+	  -e "s/PKG_VERSION/${PKG_VERSION}/g" \
+	  -e "s/BUILD_DATE/${BUILD_DATE}/g" \
+	  docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1
+
+update-man-quipucordsctl-roff:
+	$(MAKE) --no-print-directory generate-man-quipucordsctl-roff > docs/_build/quipucordsctl.1
+
+# Common man page generation steps
+generate-manpage-files:
+	$(MAKE) update-man-template-roff
+	$(MAKE) update-man-quipucordsctl-rst
+	$(MAKE) update-man-quipucordsctl-roff
+
+# Regenerate and update all man page files
+manpage:
+	$(MAKE) generate-manpage-files
+
+manpage-test:
+	@if [ -z "${OLD_MAN_PAGE_BUILD_DATE}" ]; then \
+		echo "Error: Cannot extract existing build date from docs/_build/quipucordsctl.1"; \
+		echo "The file may be missing or malformed. Run 'make manpage' first."; \
+		exit 1; \
+	fi
+	$(MAKE) generate-manpage-files BUILD_DATE="${OLD_MAN_PAGE_BUILD_DATE}"
+	git diff --exit-code docs
+	git diff --staged --exit-code docs

--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ uv run bin/translations.py update
 uv run bin/translations.py compile
 ```
 
+## man pages
+
+```sh
+# generate all man page files
+make manpage
+
+# view the generated man page
+man docs/_build/quipucordsctl.1
+
+# test that man pages are up to date (for CI)
+make manpage-test
+
+# clean generated files
+make clean
+```
+
+### downstream rebranding
+
+To generate man pages with different program/project names:
+
+```sh
+QUIPUCORDSCTL_VAR_PROGRAM_NAME=discoveryctl \
+QUIPUCORDSCTL_VAR_PROJECT=Discovery \
+make manpage
+```
+
 ## running directly from source
 
 ```sh

--- a/docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1
@@ -1,0 +1,465 @@
+.\" Man page generated from reStructuredText.
+.
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.TH "QUIPUCORDSCTL_VAR_PROGRAM_NAME" "1" "BUILD_DATE" "" "QUIPUCORDSCTL_VAR_PROGRAM_NAME"
+.SH NAME
+QUIPUCORDSCTL_VAR_PROGRAM_NAME \- Deploy and manage QUIPUCORDSCTL_VAR_PROJECT in Podman containers
+.SH SYNOPSIS
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+QUIPUCORDSCTL_VAR_PROGRAM_NAME [\-\-help] [\-v | \-\-verbose] [\-q | \-\-quiet]
+    [\-y | \-\-yes] [\-C {auto|always|never} | \-\-color {auto|always|never}]
+    [\-c DIRECTORY | \-\-override\-conf\-dir DIRECTORY]
+    COMMAND [ARGS]
+.EE
+.UNINDENT
+.UNINDENT
+.SH DESCRIPTION
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP is a command\-line management tool for QUIPUCORDSCTL_VAR_PROJECT, an agentless inspection and reporting tool that collects relevant facts about Red Hat software usage. This tool simplifies the installation, configuration, and management of QUIPUCORDSCTL_VAR_PROJECT and all of its required components to run in Podman containers on your local system.
+.sp
+The QUIPUCORDSCTL_VAR_PROGRAM_NAME tool manages the complete lifecycle of a QUIPUCORDSCTL_VAR_PROJECT deployment, including container image management, systemd service configuration, database setup, and secret management. It provides commands for installation, health checking, secret rotation, log collection, and system maintenance.
+.sp
+By default, QUIPUCORDSCTL_VAR_PROJECT configuration is stored under \fB~/.config/quipucords/\fP and application data under \fB~/.local/share/quipucords/\fP in your home directory. The QUIPUCORDSCTL_VAR_PROJECT services run as systemd user services, which means no root privileges are required for normal operation after the initial package installation.
+.sp
+This manual page describes the commands and options for the \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP command and includes usage information and example commands.
+.SH USAGE
+.sp
+The \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP command manages the QUIPUCORDSCTL_VAR_PROJECT deployment lifecycle. Within that workflow, \fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP performs the following major tasks:
+.INDENT 0.0
+.IP \(bu 2
+Installing QUIPUCORDSCTL_VAR_PROJECT:
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME install\fP
+.IP \(bu 2
+Checking system health:
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME check\fP
+.IP \(bu 2
+Resetting administrator credentials:
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password\fP
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username\fP
+.IP \(bu 2
+Collecting diagnostic logs:
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs\fP
+.IP \(bu 2
+Uninstalling QUIPUCORDSCTL_VAR_PROJECT:
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall\fP
+.UNINDENT
+.sp
+The following sections describe these commands and their options in more detail.
+.SH INSTALLATION
+.SS Installing QUIPUCORDSCTL_VAR_PROJECT
+.sp
+To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME install\fP
+.sp
+After installation, start the QUIPUCORDSCTL_VAR_PROJECT application service:
+.sp
+\fBsystemctl \-\-user restart quipucords\-app\fP
+.sp
+After a few seconds, access QUIPUCORDSCTL_VAR_PROJECT at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
+.SS Uninstalling QUIPUCORDSCTL_VAR_PROJECT
+.sp
+To completely remove QUIPUCORDSCTL_VAR_PROJECT and all its data, use the \fBuninstall\fP command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall\fP
+.INDENT 0.0
+.TP
+.B \fB\-\-keep\-data\-dirs\fP
+Preserve data directories and secrets while still removing services, unit files, and configuration. Use this to retain your data when reinstalling.
+.UNINDENT
+.SH DIAGNOSTICS
+.SS Checking System Health
+.sp
+To verify the installation status and health of QUIPUCORDSCTL_VAR_PROJECT services, use the \fBcheck\fP command. This command checks for the presence and correct permissions of data directories, certificate files, configuration files, and systemd unit files required by QUIPUCORDSCTL_VAR_PROJECT.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME check\fP
+.SS Exporting Logs
+.sp
+To export QUIPUCORDSCTL_VAR_PROJECT logs for troubleshooting, use the \fBexport_logs\fP command. This command creates a compressed archive containing log files from all running containers and systemd services.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs\fP
+.sp
+The command outputs the path to the generated log archive file.
+.SH CONFIGURATION
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME\fP provides commands for managing QUIPUCORDSCTL_VAR_PROJECT configuration and secrets. These commands allow you to reset credentials and rotate secrets without reinstalling the system.
+.SS Resetting Administrator Password
+.sp
+To reset the administrator password for the QUIPUCORDSCTL_VAR_PROJECT web interface and CLI, use the \fBreset_admin_password\fP command. This command prompts for a new password and updates the stored credentials. Set the \fBQUIPUCORDS_SERVER_PASSWORD\fP environment variable to provide a value non\-interactively.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password\fP
+.SS Resetting Administrator Username
+.sp
+To reset the administrator username for the QUIPUCORDSCTL_VAR_PROJECT web interface and CLI, use the \fBreset_admin_username\fP command. This command prompts for a new username and updates the stored credentials. Set the \fBQUIPUCORDS_SERVER_USERNAME\fP environment variable to provide a value non\-interactively.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username\fP
+.SS Resetting Database Password
+.sp
+To reset the database password used by QUIPUCORDSCTL_VAR_PROJECT, use the \fBreset_database_password\fP command. By default, this command generates a cryptographically strong random password. Set the \fBQUIPUCORDS_DBMS_PASSWORD\fP environment variable to use a specific value without prompting. Resetting this password on a running system may break the installation or cause data loss.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_database_password\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom password instead of generating a random value.
+.UNINDENT
+.SS Resetting Redis Password
+.sp
+To reset the Redis password used by QUIPUCORDSCTL_VAR_PROJECT for caching and session management, use the \fBreset_redis_password\fP command. By default, this command generates a cryptographically strong random password. Set the \fBQUIPUCORDS_REDIS_PASSWORD\fP environment variable to use a specific value without prompting. Resetting this password on a running system may cause disruption.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_redis_password\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom password instead of generating a random value.
+.UNINDENT
+.SS Resetting Encryption Secret
+.sp
+To reset the encryption secret key used to protect sensitive data stored by QUIPUCORDSCTL_VAR_PROJECT, use the \fBreset_encryption_secret\fP command. By default, this command generates a cryptographically strong random key. Set the \fBQUIPUCORDS_ENCRYPTION_SECRET_KEY\fP environment variable to use a specific value without prompting. Resetting this secret on a running system may break the installation or cause data loss.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_encryption_secret\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom secret key instead of generating a random value.
+.UNINDENT
+.SS Resetting Session Secret
+.sp
+To reset the session secret key used for web session management in QUIPUCORDSCTL_VAR_PROJECT, use the \fBreset_session_secret\fP command. By default, this command generates a cryptographically strong random key. Set the \fBQUIPUCORDS_SESSION_SECRET_KEY\fP environment variable to use a specific value without prompting. Resetting this secret on a running system may cause active sessions to become invalid.
+.sp
+\fBQUIPUCORDSCTL_VAR_PROGRAM_NAME reset_session_secret\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom secret key instead of generating a random value.
+.UNINDENT
+.SH OPTIONS FOR ALL COMMANDS
+.sp
+The following options are available for every QUIPUCORDSCTL_VAR_PROGRAM_NAME command.
+.INDENT 0.0
+.TP
+.B \fB\-\-help\fP
+Display help information for the command.
+.TP
+.B \fB\-v\fP, \fB\-\-verbose\fP
+Increase verbose output. Can be specified multiple times for more detailed logging (e.g., \fB\-vv\fP or \fB\-vvv\fP).
+.TP
+.B \fB\-q\fP, \fB\-\-quiet\fP
+Quiet output. Suppresses all non\-error messages (overrides \fB\-v\fP/\fB\-\-verbose\fP).
+.TP
+.B \fB\-y\fP, \fB\-\-yes\fP
+Automatically answer yes to all confirmation prompts.
+.TP
+.B \fB\-C\fP \fI{auto|always|never}\fP, \fB\-\-color\fP \fI{auto|always|never}\fP
+Control color output. Default is \fBauto\fP, which enables color when writing to a terminal.
+.TP
+.B \fB\-c\fP, \fB\-\-override\-conf\-dir\fP \fIDIRECTORY\fP
+Load override values from this custom configuration directory. Use this to define override values for built\-in container runtime configuration defaults that are not exposed directly through QUIPUCORDSCTL_VAR_PROGRAM_NAME commands.
+.UNINDENT
+.SH EXAMPLES
+.INDENT 0.0
+.IP \(bu 2
+Installing QUIPUCORDSCTL_VAR_PROJECT:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME install
+$ systemctl \-\-user restart quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Verifying services are running:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ systemctl \-\-user status quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with detailed progress information:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-vv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with maximum verbosity:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-vvv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking installation status:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME check
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking with verbose output:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-v check
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting administrator password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting administrator username:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting database password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_database_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting Redis password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_redis_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting encryption secret:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_encryption_secret
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting session secret:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_session_secret
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Exporting logs for troubleshooting:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Exporting logs with verbose output:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-v export_logs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Viewing service logs:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ journalctl \-\-user \-u quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Uninstalling QUIPUCORDSCTL_VAR_PROJECT:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Uninstalling QUIPUCORDSCTL_VAR_PROJECT while preserving data:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall \-\-keep\-data\-dirs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with custom config overrides:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-\-override\-conf\-dir ~/overrides install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing without confirmation prompts:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-\-yes install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing silently:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-q install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking status silently (errors only):
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ QUIPUCORDSCTL_VAR_PROGRAM_NAME \-q check
+.EE
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.SH FILES
+.INDENT 0.0
+.TP
+.B \fB~/.config/quipucords/env/\fP
+Environment files for QUIPUCORDSCTL_VAR_PROJECT container services. Contains configuration values passed to each container at startup.
+.TP
+.B \fB~/.config/containers/systemd/quipucords\-*\fP
+Podman Quadlet unit files (\fB\&.container\fP and \fB\&.network\fP) that define the QUIPUCORDSCTL_VAR_PROJECT container services.
+.TP
+.B \fB~/.local/share/quipucords/\fP
+QUIPUCORDSCTL_VAR_PROJECT application data directory. Contains the database, certificates, logs, and SSH keys.
+.TP
+.B \fB~/.local/share/containers/storage/\fP
+Podman container storage location. QUIPUCORDSCTL_VAR_PROJECT container images are stored here.
+.UNINDENT
+.SH ENVIRONMENT
+.INDENT 0.0
+.TP
+.B \fBNO_COLOR\fP
+If set, disables color output regardless of \fB\-\-color\fP setting.
+.UNINDENT
+.SH EXIT STATUS
+.INDENT 0.0
+.TP
+.B \fB0\fP
+Success. The command completed without errors.
+.TP
+.B \fB1\fP
+General error. The command failed due to invalid arguments, missing prerequisites, user interruption, or runtime errors.
+.TP
+.B \fBN\fP (any positive integer, \fBcheck\fP command only)
+The \fBcheck\fP command exits with the number of issues found. For example, if three problems are detected, the exit code is 3.
+.UNINDENT
+.SH SEE ALSO
+.sp
+\fBpodman(1)\fP, \fBsystemctl(1)\fP, \fBjournalctl(1)\fP
+.SH NOTES
+.sp
+QUIPUCORDSCTL_VAR_PROGRAM_NAME requires Podman and systemd user sessions to function. All commands except the initial RPM installation should be run as a regular non\-root user.
+.sp
+To enable the QUIPUCORDSCTL_VAR_PROJECT service to start automatically at login:
+.sp
+\fBsystemctl \-\-user enable quipucords\-app\fP
+.sp
+QUIPUCORDSCTL_VAR_PROGRAM_NAME upstream source code: \X'tty: link https://github.com/quipucords/quipucordsctl'\fI\%https://github.com/quipucords/quipucordsctl\fP\X'tty: link'
+.SH SECURITY CONSIDERATIONS
+.sp
+The configuration and environment files in \fB~/.config/quipucords/\fP are stored with user\-only permissions (mode 0600 for files, 0700 for directories). Ensure your home directory has appropriate permissions to protect these files.
+.sp
+Database passwords, Redis passwords, encryption secrets, and session secrets are stored as Podman secrets, managed by Podman\(aqs secret storage. They are not stored as plain text files in the configuration directory.
+.sp
+When using the \fB\-\-override\-conf\-dir\fP option, ensure the custom configuration directory has appropriate permissions before storing sensitive data there.
+.SH AUTHOR
+Red Hat, Inc.
+.SH COPYRIGHT
+QUIPUCORDSCTL_VAR_CURRENT_YEAR, Red Hat, Inc. Licensed under the GNU General Public License version 3.
+.\" Generated by docutils manpage writer.
+.

--- a/docs/_build/man-quipucordsctl.rst
+++ b/docs/_build/man-quipucordsctl.rst
@@ -1,0 +1,325 @@
+quipucordsctl
+==============================
+
+Synopsis
+--------
+
+.. code-block:: none
+
+   quipucordsctl [--help] [-v | --verbose] [-q | --quiet]
+       [-y | --yes] [-C {auto|always|never} | --color {auto|always|never}]
+       [-c DIRECTORY | --override-conf-dir DIRECTORY]
+       COMMAND [ARGS]
+
+Description
+-----------
+
+**quipucordsctl** is a command-line management tool for Quipucords, an agentless inspection and reporting tool that collects relevant facts about Red Hat software usage. This tool simplifies the installation, configuration, and management of Quipucords and all of its required components to run in Podman containers on your local system.
+
+The quipucordsctl tool manages the complete lifecycle of a Quipucords deployment, including container image management, systemd service configuration, database setup, and secret management. It provides commands for installation, health checking, secret rotation, log collection, and system maintenance.
+
+By default, Quipucords configuration is stored under ``~/.config/quipucords/`` and application data under ``~/.local/share/quipucords/`` in your home directory. The Quipucords services run as systemd user services, which means no root privileges are required for normal operation after the initial package installation.
+
+This manual page describes the commands and options for the ``quipucordsctl`` command and includes usage information and example commands.
+
+Usage
+-----
+
+The ``quipucordsctl`` command manages the Quipucords deployment lifecycle. Within that workflow, ``quipucordsctl`` performs the following major tasks:
+
+* Installing Quipucords:
+
+  ``quipucordsctl install``
+
+* Checking system health:
+
+  ``quipucordsctl check``
+
+* Resetting administrator credentials:
+
+  ``quipucordsctl reset_admin_password``
+
+  ``quipucordsctl reset_admin_username``
+
+* Collecting diagnostic logs:
+
+  ``quipucordsctl export_logs``
+
+* Uninstalling Quipucords:
+
+  ``quipucordsctl uninstall``
+
+The following sections describe these commands and their options in more detail.
+
+Installation
+------------
+
+Installing Quipucords
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install Quipucords and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running Quipucords.
+
+``quipucordsctl install``
+
+After installation, start the Quipucords application service:
+
+``systemctl --user restart quipucords-app``
+
+After a few seconds, access Quipucords at https://localhost:9443
+
+Uninstalling Quipucords
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To completely remove Quipucords and all its data, use the ``uninstall`` command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
+
+``quipucordsctl uninstall``
+
+``--keep-data-dirs``
+    Preserve data directories and secrets while still removing services, unit files, and configuration. Use this to retain your data when reinstalling.
+
+Diagnostics
+-----------
+
+Checking System Health
+~~~~~~~~~~~~~~~~~~~~~~
+
+To verify the installation status and health of Quipucords services, use the ``check`` command. This command checks for the presence and correct permissions of data directories, certificate files, configuration files, and systemd unit files required by Quipucords.
+
+``quipucordsctl check``
+
+Exporting Logs
+~~~~~~~~~~~~~~
+
+To export Quipucords logs for troubleshooting, use the ``export_logs`` command. This command creates a compressed archive containing log files from all running containers and systemd services.
+
+``quipucordsctl export_logs``
+
+The command outputs the path to the generated log archive file.
+
+Configuration
+-------------
+
+**quipucordsctl** provides commands for managing Quipucords configuration and secrets. These commands allow you to reset credentials and rotate secrets without reinstalling the system.
+
+Resetting Administrator Password
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the administrator password for the Quipucords web interface and CLI, use the ``reset_admin_password`` command. This command prompts for a new password and updates the stored credentials. Set the ``QUIPUCORDS_SERVER_PASSWORD`` environment variable to provide a value non-interactively.
+
+``quipucordsctl reset_admin_password``
+
+Resetting Administrator Username
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the administrator username for the Quipucords web interface and CLI, use the ``reset_admin_username`` command. This command prompts for a new username and updates the stored credentials. Set the ``QUIPUCORDS_SERVER_USERNAME`` environment variable to provide a value non-interactively.
+
+``quipucordsctl reset_admin_username``
+
+Resetting Database Password
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the database password used by Quipucords, use the ``reset_database_password`` command. By default, this command generates a cryptographically strong random password. Set the ``QUIPUCORDS_DBMS_PASSWORD`` environment variable to use a specific value without prompting. Resetting this password on a running system may break the installation or cause data loss.
+
+``quipucordsctl reset_database_password``
+
+``-p``, ``--prompt``
+    Prompt for a custom password instead of generating a random value.
+
+Resetting Redis Password
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the Redis password used by Quipucords for caching and session management, use the ``reset_redis_password`` command. By default, this command generates a cryptographically strong random password. Set the ``QUIPUCORDS_REDIS_PASSWORD`` environment variable to use a specific value without prompting. Resetting this password on a running system may cause disruption.
+
+``quipucordsctl reset_redis_password``
+
+``-p``, ``--prompt``
+    Prompt for a custom password instead of generating a random value.
+
+Resetting Encryption Secret
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the encryption secret key used to protect sensitive data stored by Quipucords, use the ``reset_encryption_secret`` command. By default, this command generates a cryptographically strong random key. Set the ``QUIPUCORDS_ENCRYPTION_SECRET_KEY`` environment variable to use a specific value without prompting. Resetting this secret on a running system may break the installation or cause data loss.
+
+``quipucordsctl reset_encryption_secret``
+
+``-p``, ``--prompt``
+    Prompt for a custom secret key instead of generating a random value.
+
+Resetting Session Secret
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the session secret key used for web session management in Quipucords, use the ``reset_session_secret`` command. By default, this command generates a cryptographically strong random key. Set the ``QUIPUCORDS_SESSION_SECRET_KEY`` environment variable to use a specific value without prompting. Resetting this secret on a running system may cause active sessions to become invalid.
+
+``quipucordsctl reset_session_secret``
+
+``-p``, ``--prompt``
+    Prompt for a custom secret key instead of generating a random value.
+
+Options for All Commands
+-------------------------
+
+The following options are available for every quipucordsctl command.
+
+``--help``
+    Display help information for the command.
+
+``-v``, ``--verbose``
+    Increase verbose output. Can be specified multiple times for more detailed logging (e.g., ``-vv`` or ``-vvv``).
+
+``-q``, ``--quiet``
+    Quiet output. Suppresses all non-error messages (overrides ``-v``/``--verbose``).
+
+``-y``, ``--yes``
+    Automatically answer yes to all confirmation prompts.
+
+``-C`` *{auto|always|never}*, ``--color`` *{auto|always|never}*
+    Control color output. Default is ``auto``, which enables color when writing to a terminal.
+
+``-c``, ``--override-conf-dir`` *DIRECTORY*
+    Load override values from this custom configuration directory. Use this to define override values for built-in container runtime configuration defaults that are not exposed directly through quipucordsctl commands.
+
+Examples
+--------
+
+* Installing Quipucords::
+
+    $ quipucordsctl install
+    $ systemctl --user restart quipucords-app
+
+* Verifying services are running::
+
+    $ systemctl --user status quipucords-app
+
+* Installing with detailed progress information::
+
+    $ quipucordsctl -vv install
+
+* Installing with maximum verbosity::
+
+    $ quipucordsctl -vvv install
+
+* Checking installation status::
+
+    $ quipucordsctl check
+
+* Checking with verbose output::
+
+    $ quipucordsctl -v check
+
+* Resetting administrator password::
+
+    $ quipucordsctl reset_admin_password
+
+* Resetting administrator username::
+
+    $ quipucordsctl reset_admin_username
+
+* Resetting database password::
+
+    $ quipucordsctl reset_database_password
+
+* Resetting Redis password::
+
+    $ quipucordsctl reset_redis_password
+
+* Resetting encryption secret::
+
+    $ quipucordsctl reset_encryption_secret
+
+* Resetting session secret::
+
+    $ quipucordsctl reset_session_secret
+
+* Exporting logs for troubleshooting::
+
+    $ quipucordsctl export_logs
+
+* Exporting logs with verbose output::
+
+    $ quipucordsctl -v export_logs
+
+* Viewing service logs::
+
+    $ journalctl --user -u quipucords-app
+
+* Uninstalling Quipucords::
+
+    $ quipucordsctl uninstall
+
+* Uninstalling Quipucords while preserving data::
+
+    $ quipucordsctl uninstall --keep-data-dirs
+
+* Installing with custom config overrides::
+
+    $ quipucordsctl --override-conf-dir ~/overrides install
+
+* Installing without confirmation prompts::
+
+    $ quipucordsctl --yes install
+
+* Installing silently::
+
+    $ quipucordsctl -q install
+
+* Checking status silently (errors only)::
+
+    $ quipucordsctl -q check
+
+Files
+-----
+
+``~/.config/quipucords/env/``
+    Environment files for Quipucords container services. Contains configuration values passed to each container at startup.
+
+``~/.config/containers/systemd/quipucords-*``
+    Podman Quadlet unit files (``.container`` and ``.network``) that define the Quipucords container services.
+
+``~/.local/share/quipucords/``
+    Quipucords application data directory. Contains the database, certificates, logs, and SSH keys.
+
+``~/.local/share/containers/storage/``
+    Podman container storage location. Quipucords container images are stored here.
+
+Environment
+-----------
+
+``NO_COLOR``
+    If set, disables color output regardless of ``--color`` setting.
+
+Exit Status
+-----------
+
+``0``
+    Success. The command completed without errors.
+
+``1``
+    General error. The command failed due to invalid arguments, missing prerequisites, user interruption, or runtime errors.
+
+``N`` (any positive integer, ``check`` command only)
+    The ``check`` command exits with the number of issues found. For example, if three problems are detected, the exit code is 3.
+
+See Also
+--------
+
+``podman(1)``, ``systemctl(1)``, ``journalctl(1)``
+
+Notes
+-----
+
+quipucordsctl requires Podman and systemd user sessions to function. All commands except the initial RPM installation should be run as a regular non-root user.
+
+To enable the Quipucords service to start automatically at login:
+
+``systemctl --user enable quipucords-app``
+
+quipucordsctl upstream source code: https://github.com/quipucords/quipucordsctl
+
+Security Considerations
+-----------------------
+
+The configuration and environment files in ``~/.config/quipucords/`` are stored with user-only permissions (mode 0600 for files, 0700 for directories). Ensure your home directory has appropriate permissions to protect these files.
+
+Database passwords, Redis passwords, encryption secrets, and session secrets are stored as Podman secrets, managed by Podman's secret storage. They are not stored as plain text files in the configuration directory.
+
+When using the ``--override-conf-dir`` option, ensure the custom configuration directory has appropriate permissions before storing sensitive data there.

--- a/docs/_build/quipucordsctl.1
+++ b/docs/_build/quipucordsctl.1
@@ -1,0 +1,465 @@
+.\" Man page generated from reStructuredText.
+.
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.TH "quipucordsctl" "1" "June 05, 2026" "" "quipucordsctl"
+.SH NAME
+quipucordsctl \- Deploy and manage Quipucords in Podman containers
+.SH SYNOPSIS
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+quipucordsctl [\-\-help] [\-v | \-\-verbose] [\-q | \-\-quiet]
+    [\-y | \-\-yes] [\-C {auto|always|never} | \-\-color {auto|always|never}]
+    [\-c DIRECTORY | \-\-override\-conf\-dir DIRECTORY]
+    COMMAND [ARGS]
+.EE
+.UNINDENT
+.UNINDENT
+.SH DESCRIPTION
+.sp
+\fBquipucordsctl\fP is a command\-line management tool for Quipucords, an agentless inspection and reporting tool that collects relevant facts about Red Hat software usage. This tool simplifies the installation, configuration, and management of Quipucords and all of its required components to run in Podman containers on your local system.
+.sp
+The quipucordsctl tool manages the complete lifecycle of a Quipucords deployment, including container image management, systemd service configuration, database setup, and secret management. It provides commands for installation, health checking, secret rotation, log collection, and system maintenance.
+.sp
+By default, Quipucords configuration is stored under \fB~/.config/quipucords/\fP and application data under \fB~/.local/share/quipucords/\fP in your home directory. The Quipucords services run as systemd user services, which means no root privileges are required for normal operation after the initial package installation.
+.sp
+This manual page describes the commands and options for the \fBquipucordsctl\fP command and includes usage information and example commands.
+.SH USAGE
+.sp
+The \fBquipucordsctl\fP command manages the Quipucords deployment lifecycle. Within that workflow, \fBquipucordsctl\fP performs the following major tasks:
+.INDENT 0.0
+.IP \(bu 2
+Installing Quipucords:
+.sp
+\fBquipucordsctl install\fP
+.IP \(bu 2
+Checking system health:
+.sp
+\fBquipucordsctl check\fP
+.IP \(bu 2
+Resetting administrator credentials:
+.sp
+\fBquipucordsctl reset_admin_password\fP
+.sp
+\fBquipucordsctl reset_admin_username\fP
+.IP \(bu 2
+Collecting diagnostic logs:
+.sp
+\fBquipucordsctl export_logs\fP
+.IP \(bu 2
+Uninstalling Quipucords:
+.sp
+\fBquipucordsctl uninstall\fP
+.UNINDENT
+.sp
+The following sections describe these commands and their options in more detail.
+.SH INSTALLATION
+.SS Installing Quipucords
+.sp
+To install Quipucords and configure all required components, use the \fBinstall\fP command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running Quipucords.
+.sp
+\fBquipucordsctl install\fP
+.sp
+After installation, start the Quipucords application service:
+.sp
+\fBsystemctl \-\-user restart quipucords\-app\fP
+.sp
+After a few seconds, access Quipucords at \X'tty: link https://localhost:9443'\fI\%https://localhost:9443\fP\X'tty: link'
+.SS Uninstalling Quipucords
+.sp
+To completely remove Quipucords and all its data, use the \fBuninstall\fP command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
+.sp
+\fBquipucordsctl uninstall\fP
+.INDENT 0.0
+.TP
+.B \fB\-\-keep\-data\-dirs\fP
+Preserve data directories and secrets while still removing services, unit files, and configuration. Use this to retain your data when reinstalling.
+.UNINDENT
+.SH DIAGNOSTICS
+.SS Checking System Health
+.sp
+To verify the installation status and health of Quipucords services, use the \fBcheck\fP command. This command checks for the presence and correct permissions of data directories, certificate files, configuration files, and systemd unit files required by Quipucords.
+.sp
+\fBquipucordsctl check\fP
+.SS Exporting Logs
+.sp
+To export Quipucords logs for troubleshooting, use the \fBexport_logs\fP command. This command creates a compressed archive containing log files from all running containers and systemd services.
+.sp
+\fBquipucordsctl export_logs\fP
+.sp
+The command outputs the path to the generated log archive file.
+.SH CONFIGURATION
+.sp
+\fBquipucordsctl\fP provides commands for managing Quipucords configuration and secrets. These commands allow you to reset credentials and rotate secrets without reinstalling the system.
+.SS Resetting Administrator Password
+.sp
+To reset the administrator password for the Quipucords web interface and CLI, use the \fBreset_admin_password\fP command. This command prompts for a new password and updates the stored credentials. Set the \fBQUIPUCORDS_SERVER_PASSWORD\fP environment variable to provide a value non\-interactively.
+.sp
+\fBquipucordsctl reset_admin_password\fP
+.SS Resetting Administrator Username
+.sp
+To reset the administrator username for the Quipucords web interface and CLI, use the \fBreset_admin_username\fP command. This command prompts for a new username and updates the stored credentials. Set the \fBQUIPUCORDS_SERVER_USERNAME\fP environment variable to provide a value non\-interactively.
+.sp
+\fBquipucordsctl reset_admin_username\fP
+.SS Resetting Database Password
+.sp
+To reset the database password used by Quipucords, use the \fBreset_database_password\fP command. By default, this command generates a cryptographically strong random password. Set the \fBQUIPUCORDS_DBMS_PASSWORD\fP environment variable to use a specific value without prompting. Resetting this password on a running system may break the installation or cause data loss.
+.sp
+\fBquipucordsctl reset_database_password\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom password instead of generating a random value.
+.UNINDENT
+.SS Resetting Redis Password
+.sp
+To reset the Redis password used by Quipucords for caching and session management, use the \fBreset_redis_password\fP command. By default, this command generates a cryptographically strong random password. Set the \fBQUIPUCORDS_REDIS_PASSWORD\fP environment variable to use a specific value without prompting. Resetting this password on a running system may cause disruption.
+.sp
+\fBquipucordsctl reset_redis_password\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom password instead of generating a random value.
+.UNINDENT
+.SS Resetting Encryption Secret
+.sp
+To reset the encryption secret key used to protect sensitive data stored by Quipucords, use the \fBreset_encryption_secret\fP command. By default, this command generates a cryptographically strong random key. Set the \fBQUIPUCORDS_ENCRYPTION_SECRET_KEY\fP environment variable to use a specific value without prompting. Resetting this secret on a running system may break the installation or cause data loss.
+.sp
+\fBquipucordsctl reset_encryption_secret\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom secret key instead of generating a random value.
+.UNINDENT
+.SS Resetting Session Secret
+.sp
+To reset the session secret key used for web session management in Quipucords, use the \fBreset_session_secret\fP command. By default, this command generates a cryptographically strong random key. Set the \fBQUIPUCORDS_SESSION_SECRET_KEY\fP environment variable to use a specific value without prompting. Resetting this secret on a running system may cause active sessions to become invalid.
+.sp
+\fBquipucordsctl reset_session_secret\fP
+.INDENT 0.0
+.TP
+.B \fB\-p\fP, \fB\-\-prompt\fP
+Prompt for a custom secret key instead of generating a random value.
+.UNINDENT
+.SH OPTIONS FOR ALL COMMANDS
+.sp
+The following options are available for every quipucordsctl command.
+.INDENT 0.0
+.TP
+.B \fB\-\-help\fP
+Display help information for the command.
+.TP
+.B \fB\-v\fP, \fB\-\-verbose\fP
+Increase verbose output. Can be specified multiple times for more detailed logging (e.g., \fB\-vv\fP or \fB\-vvv\fP).
+.TP
+.B \fB\-q\fP, \fB\-\-quiet\fP
+Quiet output. Suppresses all non\-error messages (overrides \fB\-v\fP/\fB\-\-verbose\fP).
+.TP
+.B \fB\-y\fP, \fB\-\-yes\fP
+Automatically answer yes to all confirmation prompts.
+.TP
+.B \fB\-C\fP \fI{auto|always|never}\fP, \fB\-\-color\fP \fI{auto|always|never}\fP
+Control color output. Default is \fBauto\fP, which enables color when writing to a terminal.
+.TP
+.B \fB\-c\fP, \fB\-\-override\-conf\-dir\fP \fIDIRECTORY\fP
+Load override values from this custom configuration directory. Use this to define override values for built\-in container runtime configuration defaults that are not exposed directly through quipucordsctl commands.
+.UNINDENT
+.SH EXAMPLES
+.INDENT 0.0
+.IP \(bu 2
+Installing Quipucords:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl install
+$ systemctl \-\-user restart quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Verifying services are running:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ systemctl \-\-user status quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with detailed progress information:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-vv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with maximum verbosity:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-vvv install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking installation status:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl check
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking with verbose output:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-v check
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting administrator password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_admin_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting administrator username:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_admin_username
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting database password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_database_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting Redis password:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_redis_password
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting encryption secret:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_encryption_secret
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Resetting session secret:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl reset_session_secret
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Exporting logs for troubleshooting:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl export_logs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Exporting logs with verbose output:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-v export_logs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Viewing service logs:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ journalctl \-\-user \-u quipucords\-app
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Uninstalling Quipucords:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl uninstall
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Uninstalling Quipucords while preserving data:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl uninstall \-\-keep\-data\-dirs
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing with custom config overrides:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-\-override\-conf\-dir ~/overrides install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing without confirmation prompts:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-\-yes install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Installing silently:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-q install
+.EE
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+Checking status silently (errors only):
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.EX
+$ quipucordsctl \-q check
+.EE
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.SH FILES
+.INDENT 0.0
+.TP
+.B \fB~/.config/quipucords/env/\fP
+Environment files for Quipucords container services. Contains configuration values passed to each container at startup.
+.TP
+.B \fB~/.config/containers/systemd/quipucords\-*\fP
+Podman Quadlet unit files (\fB\&.container\fP and \fB\&.network\fP) that define the Quipucords container services.
+.TP
+.B \fB~/.local/share/quipucords/\fP
+Quipucords application data directory. Contains the database, certificates, logs, and SSH keys.
+.TP
+.B \fB~/.local/share/containers/storage/\fP
+Podman container storage location. Quipucords container images are stored here.
+.UNINDENT
+.SH ENVIRONMENT
+.INDENT 0.0
+.TP
+.B \fBNO_COLOR\fP
+If set, disables color output regardless of \fB\-\-color\fP setting.
+.UNINDENT
+.SH EXIT STATUS
+.INDENT 0.0
+.TP
+.B \fB0\fP
+Success. The command completed without errors.
+.TP
+.B \fB1\fP
+General error. The command failed due to invalid arguments, missing prerequisites, user interruption, or runtime errors.
+.TP
+.B \fBN\fP (any positive integer, \fBcheck\fP command only)
+The \fBcheck\fP command exits with the number of issues found. For example, if three problems are detected, the exit code is 3.
+.UNINDENT
+.SH SEE ALSO
+.sp
+\fBpodman(1)\fP, \fBsystemctl(1)\fP, \fBjournalctl(1)\fP
+.SH NOTES
+.sp
+quipucordsctl requires Podman and systemd user sessions to function. All commands except the initial RPM installation should be run as a regular non\-root user.
+.sp
+To enable the Quipucords service to start automatically at login:
+.sp
+\fBsystemctl \-\-user enable quipucords\-app\fP
+.sp
+quipucordsctl upstream source code: \X'tty: link https://github.com/quipucords/quipucordsctl'\fI\%https://github.com/quipucords/quipucordsctl\fP\X'tty: link'
+.SH SECURITY CONSIDERATIONS
+.sp
+The configuration and environment files in \fB~/.config/quipucords/\fP are stored with user\-only permissions (mode 0600 for files, 0700 for directories). Ensure your home directory has appropriate permissions to protect these files.
+.sp
+Database passwords, Redis passwords, encryption secrets, and session secrets are stored as Podman secrets, managed by Podman\(aqs secret storage. They are not stored as plain text files in the configuration directory.
+.sp
+When using the \fB\-\-override\-conf\-dir\fP option, ensure the custom configuration directory has appropriate permissions before storing sensitive data there.
+.SH AUTHOR
+Red Hat, Inc.
+.SH COPYRIGHT
+2026, Red Hat, Inc. Licensed under the GNU General Public License version 3.
+.\" Generated by docutils manpage writer.
+.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,31 @@
+"""Sphinx configuration for quipucordsctl man page generation."""
+
+# Project information with placeholders for variable substitution
+project = "QUIPUCORDSCTL_VAR_PROGRAM_NAME"
+copyright = (
+    "QUIPUCORDSCTL_VAR_CURRENT_YEAR, Red Hat, Inc. "
+    "Licensed under the GNU General Public License version 3."
+)
+author = "Red Hat, Inc."
+release = "PKG_VERSION"
+
+# Use man-template as the root document directly (no index.rst needed)
+root_doc = "man-template"
+
+# Man page output configuration
+# Format: (source, name, description, authors, section)
+man_pages = [
+    (
+        "man-template",
+        "QUIPUCORDSCTL_VAR_PROGRAM_NAME",
+        "Deploy and manage QUIPUCORDSCTL_VAR_PROJECT in Podman containers",
+        [author],
+        1,  # section 1 = user commands
+    ),
+]
+
+# Minimal extensions (none needed for basic man pages)
+extensions = []
+
+# Suppress warnings
+suppress_warnings = ["man.unknown_section"]

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -1,0 +1,325 @@
+QUIPUCORDSCTL_VAR_PROGRAM_NAME
+==============================
+
+Synopsis
+--------
+
+.. code-block:: none
+
+   QUIPUCORDSCTL_VAR_PROGRAM_NAME [--help] [-v | --verbose] [-q | --quiet]
+       [-y | --yes] [-C {auto|always|never} | --color {auto|always|never}]
+       [-c DIRECTORY | --override-conf-dir DIRECTORY]
+       COMMAND [ARGS]
+
+Description
+-----------
+
+**QUIPUCORDSCTL_VAR_PROGRAM_NAME** is a command-line management tool for QUIPUCORDSCTL_VAR_PROJECT, an agentless inspection and reporting tool that collects relevant facts about Red Hat software usage. This tool simplifies the installation, configuration, and management of QUIPUCORDSCTL_VAR_PROJECT and all of its required components to run in Podman containers on your local system.
+
+The QUIPUCORDSCTL_VAR_PROGRAM_NAME tool manages the complete lifecycle of a QUIPUCORDSCTL_VAR_PROJECT deployment, including container image management, systemd service configuration, database setup, and secret management. It provides commands for installation, health checking, secret rotation, log collection, and system maintenance.
+
+By default, QUIPUCORDSCTL_VAR_PROJECT configuration is stored under ``~/.config/quipucords/`` and application data under ``~/.local/share/quipucords/`` in your home directory. The QUIPUCORDSCTL_VAR_PROJECT services run as systemd user services, which means no root privileges are required for normal operation after the initial package installation.
+
+This manual page describes the commands and options for the ``QUIPUCORDSCTL_VAR_PROGRAM_NAME`` command and includes usage information and example commands.
+
+Usage
+-----
+
+The ``QUIPUCORDSCTL_VAR_PROGRAM_NAME`` command manages the QUIPUCORDSCTL_VAR_PROJECT deployment lifecycle. Within that workflow, ``QUIPUCORDSCTL_VAR_PROGRAM_NAME`` performs the following major tasks:
+
+* Installing QUIPUCORDSCTL_VAR_PROJECT:
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME install``
+
+* Checking system health:
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME check``
+
+* Resetting administrator credentials:
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password``
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username``
+
+* Collecting diagnostic logs:
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs``
+
+* Uninstalling QUIPUCORDSCTL_VAR_PROJECT:
+
+  ``QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall``
+
+The following sections describe these commands and their options in more detail.
+
+Installation
+------------
+
+Installing QUIPUCORDSCTL_VAR_PROJECT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install QUIPUCORDSCTL_VAR_PROJECT and configure all required components, use the ``install`` command. This command sets up container volumes, generates initial secrets, creates systemd service unit files, and prepares the environment for running QUIPUCORDSCTL_VAR_PROJECT.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME install``
+
+After installation, start the QUIPUCORDSCTL_VAR_PROJECT application service:
+
+``systemctl --user restart quipucords-app``
+
+After a few seconds, access QUIPUCORDSCTL_VAR_PROJECT at https://localhost:9443
+
+Uninstalling QUIPUCORDSCTL_VAR_PROJECT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To completely remove QUIPUCORDSCTL_VAR_PROJECT and all its data, use the ``uninstall`` command. This command stops all running services, removes systemd unit files, removes secrets and configuration files, and deletes all data directories.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall``
+
+``--keep-data-dirs``
+    Preserve data directories and secrets while still removing services, unit files, and configuration. Use this to retain your data when reinstalling.
+
+Diagnostics
+-----------
+
+Checking System Health
+~~~~~~~~~~~~~~~~~~~~~~
+
+To verify the installation status and health of QUIPUCORDSCTL_VAR_PROJECT services, use the ``check`` command. This command checks for the presence and correct permissions of data directories, certificate files, configuration files, and systemd unit files required by QUIPUCORDSCTL_VAR_PROJECT.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME check``
+
+Exporting Logs
+~~~~~~~~~~~~~~
+
+To export QUIPUCORDSCTL_VAR_PROJECT logs for troubleshooting, use the ``export_logs`` command. This command creates a compressed archive containing log files from all running containers and systemd services.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs``
+
+The command outputs the path to the generated log archive file.
+
+Configuration
+-------------
+
+**QUIPUCORDSCTL_VAR_PROGRAM_NAME** provides commands for managing QUIPUCORDSCTL_VAR_PROJECT configuration and secrets. These commands allow you to reset credentials and rotate secrets without reinstalling the system.
+
+Resetting Administrator Password
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the administrator password for the QUIPUCORDSCTL_VAR_PROJECT web interface and CLI, use the ``reset_admin_password`` command. This command prompts for a new password and updates the stored credentials. Set the ``QUIPUCORDS_SERVER_PASSWORD`` environment variable to provide a value non-interactively.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password``
+
+Resetting Administrator Username
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the administrator username for the QUIPUCORDSCTL_VAR_PROJECT web interface and CLI, use the ``reset_admin_username`` command. This command prompts for a new username and updates the stored credentials. Set the ``QUIPUCORDS_SERVER_USERNAME`` environment variable to provide a value non-interactively.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username``
+
+Resetting Database Password
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the database password used by QUIPUCORDSCTL_VAR_PROJECT, use the ``reset_database_password`` command. By default, this command generates a cryptographically strong random password. Set the ``QUIPUCORDS_DBMS_PASSWORD`` environment variable to use a specific value without prompting. Resetting this password on a running system may break the installation or cause data loss.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_database_password``
+
+``-p``, ``--prompt``
+    Prompt for a custom password instead of generating a random value.
+
+Resetting Redis Password
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the Redis password used by QUIPUCORDSCTL_VAR_PROJECT for caching and session management, use the ``reset_redis_password`` command. By default, this command generates a cryptographically strong random password. Set the ``QUIPUCORDS_REDIS_PASSWORD`` environment variable to use a specific value without prompting. Resetting this password on a running system may cause disruption.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_redis_password``
+
+``-p``, ``--prompt``
+    Prompt for a custom password instead of generating a random value.
+
+Resetting Encryption Secret
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the encryption secret key used to protect sensitive data stored by QUIPUCORDSCTL_VAR_PROJECT, use the ``reset_encryption_secret`` command. By default, this command generates a cryptographically strong random key. Set the ``QUIPUCORDS_ENCRYPTION_SECRET_KEY`` environment variable to use a specific value without prompting. Resetting this secret on a running system may break the installation or cause data loss.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_encryption_secret``
+
+``-p``, ``--prompt``
+    Prompt for a custom secret key instead of generating a random value.
+
+Resetting Session Secret
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To reset the session secret key used for web session management in QUIPUCORDSCTL_VAR_PROJECT, use the ``reset_session_secret`` command. By default, this command generates a cryptographically strong random key. Set the ``QUIPUCORDS_SESSION_SECRET_KEY`` environment variable to use a specific value without prompting. Resetting this secret on a running system may cause active sessions to become invalid.
+
+``QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_session_secret``
+
+``-p``, ``--prompt``
+    Prompt for a custom secret key instead of generating a random value.
+
+Options for All Commands
+-------------------------
+
+The following options are available for every QUIPUCORDSCTL_VAR_PROGRAM_NAME command.
+
+``--help``
+    Display help information for the command.
+
+``-v``, ``--verbose``
+    Increase verbose output. Can be specified multiple times for more detailed logging (e.g., ``-vv`` or ``-vvv``).
+
+``-q``, ``--quiet``
+    Quiet output. Suppresses all non-error messages (overrides ``-v``/``--verbose``).
+
+``-y``, ``--yes``
+    Automatically answer yes to all confirmation prompts.
+
+``-C`` *{auto|always|never}*, ``--color`` *{auto|always|never}*
+    Control color output. Default is ``auto``, which enables color when writing to a terminal.
+
+``-c``, ``--override-conf-dir`` *DIRECTORY*
+    Load override values from this custom configuration directory. Use this to define override values for built-in container runtime configuration defaults that are not exposed directly through QUIPUCORDSCTL_VAR_PROGRAM_NAME commands.
+
+Examples
+--------
+
+* Installing QUIPUCORDSCTL_VAR_PROJECT::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME install
+    $ systemctl --user restart quipucords-app
+
+* Verifying services are running::
+
+    $ systemctl --user status quipucords-app
+
+* Installing with detailed progress information::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -vv install
+
+* Installing with maximum verbosity::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -vvv install
+
+* Checking installation status::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME check
+
+* Checking with verbose output::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -v check
+
+* Resetting administrator password::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_password
+
+* Resetting administrator username::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_admin_username
+
+* Resetting database password::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_database_password
+
+* Resetting Redis password::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_redis_password
+
+* Resetting encryption secret::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_encryption_secret
+
+* Resetting session secret::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME reset_session_secret
+
+* Exporting logs for troubleshooting::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME export_logs
+
+* Exporting logs with verbose output::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -v export_logs
+
+* Viewing service logs::
+
+    $ journalctl --user -u quipucords-app
+
+* Uninstalling QUIPUCORDSCTL_VAR_PROJECT::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall
+
+* Uninstalling QUIPUCORDSCTL_VAR_PROJECT while preserving data::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME uninstall --keep-data-dirs
+
+* Installing with custom config overrides::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME --override-conf-dir ~/overrides install
+
+* Installing without confirmation prompts::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME --yes install
+
+* Installing silently::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -q install
+
+* Checking status silently (errors only)::
+
+    $ QUIPUCORDSCTL_VAR_PROGRAM_NAME -q check
+
+Files
+-----
+
+``~/.config/quipucords/env/``
+    Environment files for QUIPUCORDSCTL_VAR_PROJECT container services. Contains configuration values passed to each container at startup.
+
+``~/.config/containers/systemd/quipucords-*``
+    Podman Quadlet unit files (``.container`` and ``.network``) that define the QUIPUCORDSCTL_VAR_PROJECT container services.
+
+``~/.local/share/quipucords/``
+    QUIPUCORDSCTL_VAR_PROJECT application data directory. Contains the database, certificates, logs, and SSH keys.
+
+``~/.local/share/containers/storage/``
+    Podman container storage location. QUIPUCORDSCTL_VAR_PROJECT container images are stored here.
+
+Environment
+-----------
+
+``NO_COLOR``
+    If set, disables color output regardless of ``--color`` setting.
+
+Exit Status
+-----------
+
+``0``
+    Success. The command completed without errors.
+
+``1``
+    General error. The command failed due to invalid arguments, missing prerequisites, user interruption, or runtime errors.
+
+``N`` (any positive integer, ``check`` command only)
+    The ``check`` command exits with the number of issues found. For example, if three problems are detected, the exit code is 3.
+
+See Also
+--------
+
+``podman(1)``, ``systemctl(1)``, ``journalctl(1)``
+
+Notes
+-----
+
+QUIPUCORDSCTL_VAR_PROGRAM_NAME requires Podman and systemd user sessions to function. All commands except the initial RPM installation should be run as a regular non-root user.
+
+To enable the QUIPUCORDSCTL_VAR_PROJECT service to start automatically at login:
+
+``systemctl --user enable quipucords-app``
+
+QUIPUCORDSCTL_VAR_PROGRAM_NAME upstream source code: https://github.com/quipucords/quipucordsctl
+
+Security Considerations
+-----------------------
+
+The configuration and environment files in ``~/.config/quipucords/`` are stored with user-only permissions (mode 0600 for files, 0700 for directories). Ensure your home directory has appropriate permissions to protect these files.
+
+Database passwords, Redis passwords, encryption secrets, and session secrets are stored as Podman secrets, managed by Podman's secret storage. They are not stored as plain text files in the configuration directory.
+
+When using the ``--override-conf-dir`` option, ensure the custom configuration directory has appropriate permissions before storing sensitive data there.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "pytest-timeout>=2.4.0",
     "ruff>=0.12.2",
 ]
+build = [
+    "sphinx>=7.2.6,<8",
+]
 
 [tool.ruff]
 lint.select = [

--- a/quipucordsctl.spec
+++ b/quipucordsctl.spec
@@ -135,6 +135,16 @@ mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_datadir}/%{name}/env
 cp %{templates_dir}/env/*.env %{buildroot}/%{_datadir}/%{name}/env/
 
+# Install man page with variable replacements
+mkdir -p %{buildroot}%{_mandir}/man1/
+sed \
+  -e "s/QUIPUCORDSCTL_VAR_PROGRAM_NAME/%{name}/g" \
+  -e "s/QUIPUCORDSCTL_VAR_PROJECT/%{product_name_title}/g" \
+  -e "s/QUIPUCORDSCTL_VAR_CURRENT_YEAR/$(date +'%Y')/g" \
+  -e "s/BUILD_DATE/$(date +'%B %d, %Y')/g" \
+  docs/_build/QUIPUCORDSCTL_VAR_PROGRAM_NAME.1 > \
+  %{buildroot}%{_mandir}/man1/%{name}.1
+
 # Copy and rename original source files with appropriate branding.
 mkdir -p %{buildroot}/%{_datadir}/%{name}/config
 cp %{templates_dir}/config/quipucords-app.container %{buildroot}/%{_datadir}/%{name}/config/%{product_name_lower}-app.container
@@ -156,6 +166,7 @@ sed -i 's#^Image=.*#Image=%{ui_image}#g' %{buildroot}/%{_datadir}/%{name}/config
 %files
 %license LICENSE
 %doc README.md
+%doc %{_mandir}/man1/%{name}.*
 %{_bindir}/%{name}
 %{_datadir}/%{name}/config/%{product_name_lower}.network
 %{_datadir}/%{name}/config/%{product_name_lower}-app.container

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,103 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "alabaster"
+version = "0.7.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -71,7 +162,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
     { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
     { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
 ]
 
 [[package]]
@@ -87,12 +217,105 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -182,6 +405,9 @@ version = "2.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
+build = [
+    { name = "sphinx" },
+]
 dev = [
     { name = "babel" },
     { name = "coverage" },
@@ -196,6 +422,7 @@ dev = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+build = [{ name = "sphinx", specifier = ">=7.2.6,<8" }]
 dev = [
     { name = "babel", specifier = ">=2.17.0" },
     { name = "coverage", specifier = ">=7.9.2" },
@@ -205,6 +432,21 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.12.2" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -233,10 +475,109 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/ee/67eef9600338e245ad7838230969a34c823ddbdbccc5e1fc43cd75b55bc9/snowballstemmer-3.1.0.tar.gz", hash = "sha256:fd9e34526b23340cd23ffea6c9f9760974ecc2c2ac9e1d81401443ccdb2a801f", size = 122523, upload-time = "2026-05-24T19:04:19.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/83/ddbf4533c62dd32667ef1238952abef155f3d3391f5be69a352ad1638a42/snowballstemmer-3.1.0-py3-none-any.whl", hash = "sha256:17e6d1da216aa07db6dad37139ea70cf13c4b2e9a096f6e64a9648fc657d3154", size = 104550, upload-time = "2026-05-24T19:04:18.026Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "7.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
- Add Sphinx-based man page generation using RST templates
- Create comprehensive man page documenting all commands and options
- Merge man page generation targets into root Makefile
- Add GitHub CI test (manpage-test) to verify man pages are up-to-date
- Exclude Sphinx build artifacts (.doctrees) from git

The man page documents all 10 non-hidden commands, and the man page structure follows qpc's pattern with comprehensive sections.

Relates to JIRA: DISCOVERY-1126

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add Sphinx-based infrastructure and workflows to generate, package, and validate the quipucordsctl man page, including support for downstream rebranding.

New Features:
- Introduce Makefile targets and Sphinx configuration to generate quipucordsctl man pages from a reusable template, producing both placeholder and upstream roff/RST outputs.

Enhancements:
- Install the generated man page into the RPM as packaged documentation and extend cleanup to cover generated artifacts.

Build:
- Add a dedicated build dependency group including Sphinx for man page generation and wire manpage targets into the root Makefile.

CI:
- Extend the GitHub Actions test matrix with a manpage-test job that regenerates man pages and fails if committed outputs are out of date.

Documentation:
- Document man page usage, testing, cleanup, and downstream rebranding workflows in the README, and add Sphinx source and generated man page files to the repository.

Tests:
- Add a manpage-test Makefile target that regenerates man pages with a fixed build date and verifies no changes under docs/ via git diff.